### PR TITLE
Fix issue when claim.aud is an array

### DIFF
--- a/src/oauth-service.ts
+++ b/src/oauth-service.ts
@@ -338,9 +338,16 @@ export class OAuthService {
             var claims = JSON.parse(claimsJson);
             var savedNonce = this._storage.getItem("nonce");
             
-            if (claims.aud !== this.clientId) {
-                console.warn("Wrong audience: " + claims.aud);
-                return false;
+            if (Array.isArray(claims.aud)) {
+                if (claims.aud.every(v => v !== this.clientId)) {
+                    console.warn("Wrong audience: " + claims.aud.join(","));
+                    return false;
+                }
+            } else {
+                if (claims.aud !== this.clientId) {
+                    console.warn("Wrong audience: " + claims.aud);
+                    return false;
+                }
             }
 
             if (this.issuer && claims.iss !== this.issuer) {


### PR DESCRIPTION
WSO2 Identity Server returns aud as an array which breaks the guard at line 341 in oauth-service.ts. This pull request modifies the guard to properly handle this situation.