### PR TITLE
add optional headers for username password flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-oauth2-oidc",
-  "version": "1.0.20",
+  "version": "1.0.21-SNAPSHOT",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",

--- a/src/oauth-service.ts
+++ b/src/oauth-service.ts
@@ -78,7 +78,7 @@ export class OAuthService {
 
     }
 
-    fetchTokenUsingPasswordFlowAndLoadUserProfile(userName: string, password: string, headers?: Headers = new Headers()) {
+    fetchTokenUsingPasswordFlowAndLoadUserProfile(userName: string, password: string, headers: Headers = new Headers()) {
         return this
                 .fetchTokenUsingPasswordFlow(userName, password, headers)
                 .then(() => this.loadUserProfile());
@@ -108,7 +108,7 @@ export class OAuthService {
 
     }
 
-    fetchTokenUsingPasswordFlow(userName: string, password: string, headers?: Headers = new Headers()) {
+    fetchTokenUsingPasswordFlow(userName: string, password: string, headers: Headers = new Headers()) {
 
         return new Promise((resolve, reject) => { 
             let search = new URLSearchParams();

--- a/src/oauth-service.ts
+++ b/src/oauth-service.ts
@@ -78,9 +78,9 @@ export class OAuthService {
 
     }
 
-    fetchTokenUsingPasswordFlowAndLoadUserProfile(userName: string, password: string) {
+    fetchTokenUsingPasswordFlowAndLoadUserProfile(userName: string, password: string, headers?: Headers = new Headers()) {
         return this
-                .fetchTokenUsingPasswordFlow(userName, password)
+                .fetchTokenUsingPasswordFlow(userName, password, headers)
                 .then(() => this.loadUserProfile());
     }
 
@@ -108,7 +108,7 @@ export class OAuthService {
 
     }
 
-    fetchTokenUsingPasswordFlow(userName: string, password: string) {
+    fetchTokenUsingPasswordFlow(userName: string, password: string, headers?: Headers = new Headers()) {
 
         return new Promise((resolve, reject) => { 
             let search = new URLSearchParams();
@@ -122,7 +122,6 @@ export class OAuthService {
                 search.set('client_secret', this.dummyClientSecret);
             }
 
-            let headers = new Headers();
             headers.set('Content-Type', 'application/x-www-form-urlencoded');
 
             let params = search.toString();


### PR DESCRIPTION
I have added the option to pass customised headers to the fetchTokenUsingPasswordFlow. I am calling a security service that requires basic authentication before I can POST the user credentials to obtain a token. 