### PR TITLE
Fixes #23 - Check for URI encoding before split state

### DIFF
--- a/src/oauth-service.ts
+++ b/src/oauth-service.ts
@@ -279,6 +279,13 @@ export class OAuthService {
 
         var savedNonce = this._storage.getItem("nonce");
 
+        // Our state might be URL encoded
+        // Check for this and then decode it if it is
+        let decodedState = decodeURIComponent(state);
+        if (decodedState != state) {
+          state = decodedState;
+        }
+        
         var stateParts = state.split(';');
         var nonceInState = stateParts[0];
         if (savedNonce === nonceInState) {


### PR DESCRIPTION
This fixes issue #23 in the library whereby if the returning state is url encoded, the nonce cannot be split from the state string and verified.

The changes decode the state and check if the decoded state is the same as the provided state. If they are different, the decoded state is used.