### PR TITLE
Update import module name in README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -157,7 +157,7 @@ export class AppComponent {
 
 ```
 import { Component } from '@angular/core';
-import { OAuthService } from 'angular2-oauth2/oauth-service';
+import { OAuthService } from 'angular-oauth2-oidc';
 
 @Component({
     templateUrl: "app/home.html" 


### PR DESCRIPTION
Edited module name from import in Home-Component Example. It had the old module name 'angular2-oauth2/oauth-service' to import the OAuthService.