### PR TITLE
Accessing localstorage via try/catch

### DIFF
--- a/src/oauth-service.ts
+++ b/src/oauth-service.ts
@@ -40,9 +40,16 @@ export class OAuthService {
         this._storage = storage;
     }
     
-    private _storage: Storage = localStorage;
+    private _storage: Storage;
 
     constructor(private http: Http) {
+        // Access to localstorage might be a probleme in IE and Edge
+        try {
+            this._storage = localStorage;
+        } catch (err) {
+            this._storage = sessionStorage;
+        }
+        
         this.discoveryDocumentLoaded$ = Observable.create(sender => {
             this.discoveryDocumentLoadedSender = sender;
         }).publish().connect();


### PR DESCRIPTION
Accessing localstorage in IE and Edge can crash the whole application:
![image](https://user-images.githubusercontent.com/9371455/29220358-1480d040-7ebb-11e7-964a-fbef5b77efe2.png)
![image](https://user-images.githubusercontent.com/9371455/29220392-30ececbe-7ebb-11e7-9edc-a67a1268963a.png)

The recommended way is to always access localstorage via try/catch;
This problem will fix issue #51.