### PR TITLE
Make parameter login_hint optional

### DIFF
--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -752,9 +752,11 @@ export class OAuthService {
                         + "&redirect_uri=" 
                         + encodeURIComponent(redirectUri) 
                         + "&scope=" 
-                        + encodeURIComponent(scope)
-                        + "&login_hint="
-                        + encodeURIComponent(loginHint);
+                        + encodeURIComponent(scope);
+            
+            if (loginHint) {
+                url += "&login_hint=" + encodeURIComponent(loginHint);
+            }
 
             if (that.resource) {
                 url += "&resource=" + encodeURIComponent(that.resource);


### PR DESCRIPTION
GET-Parameter `&login_hint` is only set if it has a value.

The server I am using does not play nicely if there is a `&login_hint=` at the end of the Query-String.