### PR TITLE
fix: missing HttpModule dependency

### DIFF
--- a/angular-oauth2-oidc/src/index.ts
+++ b/angular-oauth2-oidc/src/index.ts
@@ -25,7 +25,8 @@ export * from './tokens';
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule,
+    HttpModule
   ],
   declarations: [
   ],


### PR DESCRIPTION
Although HttpModule is going to be deprecated in v5, we should have it in imports until you switch to use HttpClientModule.