### PR TITLE
Add 'logout' event

### DIFF
--- a/angular-oauth2-oidc/src/events.ts
+++ b/angular-oauth2-oidc/src/events.ts
@@ -18,7 +18,8 @@ export type EventType =
 | 'token_expires'
 | 'session_changed'
 | 'session_error'
-| 'session_terminated';
+| 'session_terminated'
+| 'logout';
 
 export abstract class OAuthEvent {
     constructor(

--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -1398,6 +1398,8 @@ export class OAuthService
         this._storage.removeItem('access_token_stored_at');
         
         this.silentRefreshSubject = null;
+      
+        this.eventsSubject.next(new OAuthInfoEvent('logout'));
 
         if (!this.logoutUrl) return;
         if (noRedirectToLogoutUrl) return;


### PR DESCRIPTION
This PR adds the 'logout' event to notify subscribers that the `logout()` function was called.

There is currently a 'session_terminated' event but that is not always emitted when `logout()` is called. (e.g. when `this.logoutUrl` is null or `noRedirectToLogoutUrl` is false).