### PR TITLE
Fixed the issue when logout URL has a parameter

### DIFF
--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -1412,10 +1412,12 @@ export class OAuthService
             logoutUrl = this.logoutUrl.replace(/\{\{id_token\}\}/, id_token);
         }
         else {
-            logoutUrl = this.logoutUrl + '?id_token_hint='
-                                + encodeURIComponent(id_token)
-                                + '&post_logout_redirect_uri='
-                                + encodeURIComponent(this.postLogoutRedirectUri || this.redirectUri);
+            logoutUrl = this.logoutUrl +
+                (this.logoutUrl.indexOf('?') > -1 ? '&' : '?')
+                + 'id_token_hint='
+                + encodeURIComponent(id_token)
+                + '&post_logout_redirect_uri='
+                + encodeURIComponent(this.postLogoutRedirectUri || this.redirectUri);
         }
         location.href = logoutUrl;
     };


### PR DESCRIPTION
When the logout URL has a parameter, the URL was constructed incorrectly, first parameter would be added with a "?" instead of a "&", which resulted in an URL with two "?" which is invalid.

Corrected by checking if the URL already contains a "?", and if it does, add the first parameter with a "&" instead of a "?".

Fixes #134