### PR TITLE
sample: remove erroneous key 'siletRefreshTimeout'

### DIFF
--- a/sample/src/app/auth-no-discovery.config.ts
+++ b/sample/src/app/auth-no-discovery.config.ts
@@ -21,7 +21,6 @@ export const noDiscoveryAuthConfig: AuthConfig = {
   'silentRefreshRedirectUri': 'http://localhost:4200/silent-refresh.html',
   'silentRefreshMessagePrefix': '',
   'silentRefreshShowIFrame': false,
-  'siletRefreshTimeout': 20000,
   'silentRefreshTimeout': 20000,
   'dummyClientSecret': null,
   'requireHttps': 'remoteOnly',


### PR DESCRIPTION
Before, `ng serve` in sample/ would fail with

    ERROR in sample/src/app/auth-no-discovery.config.ts (24,3): Type '{ 'clientId': string; 'redirectUri': string; 'postLogoutRedirectUri': string; 'loginUrl': string;...' is not assignable to type 'AuthConfig'.
      Object literal may only specify known properties, and ''siletRefreshTimeout'' does not exist in type 'AuthConfig'
