### PR TITLE
Include resource in password flow token query, if set

### DIFF
--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -535,6 +535,10 @@ export class OAuthService
             search.set('username', userName);
             search.set('password', password);
 
+            if(this.resource) {
+                search.set('resource', this.resource);
+            }
+
             if (this.dummyClientSecret) {
                 search.set('client_secret', this.dummyClientSecret);
             }


### PR DESCRIPTION
Issue #158 Azure AD is requiring a 'resource' parameter be included in the query; this adds that value if it is present.