### PR TITLE
Use of LoginOptions

### DIFF
--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -156,15 +156,15 @@ export class OAuthService
         this.restartRefreshTimerIfStillLoggedIn();
     }
 
-    public loadDiscoveryDocumentAndTryLogin() {
+    public loadDiscoveryDocumentAndTryLogin(options: LoginOptions = null) {
         return this.loadDiscoveryDocument().then((doc) => {
-            return this.tryLogin();
+            return this.tryLogin(options);
         });
     }
 
 
-    public loadDiscoveryDocumentAndLogin() {
-        this.loadDiscoveryDocumentAndTryLogin().then(_ => {
+    public loadDiscoveryDocumentAndLogin(options: LoginOptions = null) {
+        this.loadDiscoveryDocumentAndTryLogin(options).then(_ => {
             if (!this.hasValidIdToken() || !this.hasValidAccessToken()) {
               this.initImplicitFlow();
             }


### PR DESCRIPTION
This is about the loadDiscoveryDocumentAndTryLogin and the loadDiscoveryDocumentAndLogin methods, that both using the tryLogin method internally. The tryLogin Method has the optional parameter options of type loginOptions. This pull request extends the former methods with an options parameter.
