### PR TITLE
Implicit flow

### DIFF
--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -988,20 +988,20 @@ export class OAuthService
     };
 
     initImplicitFlowInternal(additionalState = '', params: string | object = ''): void {
-        
+
         if (this.inImplicitFlow) {
             return;
         }
 
         this.inImplicitFlow = true;
-        
+
         if (!this.validateUrlForHttps(this.loginUrl)) {
             throw new Error('loginUrl must use Http. Also check property requireHttps.');
         }
-        
+
         let addParams: object = {};
         let loginHint: string = null;
-        
+
         if (typeof params === 'string') {
             loginHint = params;
         }
@@ -1018,7 +1018,7 @@ export class OAuthService
             this.inImplicitFlow = false;
         });
     };
-    
+
     /**
      * Starts the implicit flow and redirects to user to
      * the auth servers login url.
@@ -1139,7 +1139,7 @@ export class OAuthService
         if (!this.oidc) {
             this.eventsSubject.next(new OAuthSuccessEvent('token_received'));
             return Promise.resolve();  
-        } 
+        }
 
         return this
                 .processIdToken(idToken, accessToken)


### PR DESCRIPTION
## Guard protected components

leads to two effects

### Outpaced loading of discovery document

If a CanActivate or CanLoad guard is initializing the implicit flow, this may occur before the discover document is loaded and the loginUrl is initialized. The effect is, that an login url just consisting of the parameter part is constructed and thus redirect to the app component. The app component on her site again starts the loading of the discovery document and perhaps (loadDiscoveryDocumentAndLogin) another implicit flow.
This pull request changes the initImplicitFlow in a manner, that it checks wether the loginUrl is not an empty string or else subscribes to the discovery_document_loaded event to build up the login url to redirect to.

### Outpaced implicit flow

In the case of an implicit flow initialized by an CanActivate or CanLoad guard the developer potentially hands over the path to the additionalState paramenter in order to redirect after successfull login.

If the loadDiscoveryDocumentAndLogin method is used from the app component a second implicit flow is initialized which interjects the one initialized by the CanActivate or CanLoad guard and thus overwrites the additionalState. 

This is the second subject of this pull request. By setting a flag inImplicitFlow and checking for it, unintended subsequent initializations of the implicit flow are prevented. 
