### PR TITLE
Add support to PingFederate SLO

### DIFF
--- a/angular-oauth2-oidc/src/auth.config.ts
+++ b/angular-oauth2-oidc/src/auth.config.ts
@@ -38,6 +38,17 @@ export class AuthConfig {
     public oidc? = true;
 
     /**
+     * Temporary implementation to cover gaps from PingFederate while it has not OpenID Connect
+     * Session Management implemented yet
+     *
+     * Defines which cases PingFederate mismatches to OpenID should be considered.
+     * Refers to:
+     * * https://ping.force.com/Support/Group-Detail/PingFederate-Q&A/Feed-Detail/feedId_0D54000003BOpaaCAD
+     * * https://stackoverflow.com/questions/24669039/pingfederate-idp-initiated-logout-redirect-to-targetresource
+     */
+    public usePingFederate? = false;
+
+    /**
      * Defines whether to request a access token during
      * implicit flow.
      */

--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -349,8 +349,12 @@ export class OAuthService
                         return;
                     }
 
+                    // See: https://ping.force.com/Support/Group-Detail/PingFederate-Q&A/Feed-Detail/feedId_0D54000003BOpaaCAD
+                    this.logoutUrl = this.config.usePingFederate
+                        ? doc.ping_end_session_endpoint
+                        : doc.end_session_endpoint;
+
                     this.loginUrl = doc.authorization_endpoint;
-                    this.logoutUrl = doc.end_session_endpoint;
                     this.grantTypesSupported = doc.grant_types_supported;
                     this.issuer = doc.issuer;
                     this.tokenEndpoint = doc.token_endpoint;
@@ -1488,11 +1492,16 @@ export class OAuthService
             logoutUrl = this.logoutUrl.replace(/\{\{id_token\}\}/, id_token);
         }
         else {
+            // See: https://stackoverflow.com/questions/24669039/pingfederate-idp-initiated-logout-redirect-to-targetresource
+            const redirectUrlParamKey = this.config.usePingFederate
+                ? '&TargetResource='
+                : '&post_logout_redirect_uri=';
+
             logoutUrl = this.logoutUrl +
                 (this.logoutUrl.indexOf('?') > -1 ? '&' : '?')
                 + 'id_token_hint='
                 + encodeURIComponent(id_token)
-                + '&post_logout_redirect_uri='
+                + redirectUrlParamKey
                 + encodeURIComponent(this.postLogoutRedirectUri || this.redirectUri);
         }
         location.href = logoutUrl;

--- a/angular-oauth2-oidc/src/types.ts
+++ b/angular-oauth2-oidc/src/types.ts
@@ -133,5 +133,8 @@ export interface OidcDiscoveryDoc {
     claims_parameter_supported: boolean;
     service_documentation: string;
     ui_locales_supported: string[];
+
+    // See: https://ping.force.com/Support/Group-Detail/PingFederate-Q&A/Feed-Detail/feedId_0D54000003BOpaaCAD
+    ping_end_session_endpoint?: string;
 }
 


### PR DESCRIPTION
Dear @manfredsteyer,

I'd like to integrate the changes I've implemented to match the PingFederate implementation of OpenID. There are only two gaps between the OpenID specification and the current PingFederate implementation, also added into the code:

- Different name for `end_session_endpoint` property: https://ping.force.com/Support/Group-Detail/PingFederate-Q&A/Feed-Detail/feedId_0D54000003BOpaaCAD

- Different name for `post_logout_redirect_uri` parameter in logout URL: https://stackoverflow.com/questions/24669039/pingfederate-idp-initiated-logout-redirect-to-targetresource

Nevertheless, they might be controlled by a config flag, while the default value should always be the OpenID specification:

I know that the focus isn't each specific characteristics of providers, like PingFederate. However, it's a temporary solution to match two single differences. I wouldn't have an impact on the current version for dependent applications, neither would introduce breaking changes.

Please, consider that those incompatibilities are temporary and PingFederate is planning in a short-term have 100% compatible OpenID implementation.

Thanks in advance for the comprehension. I completely understand if the merge can't be done. In addition, I could work in a separate branch, but also keeping the credits to the author, of course.

NB: I tried to find unit tests in the library, but it seems they aren't available.

Best,
@alexndreazevedo