### PR TITLE
fix interceptor - only add Authorization header when token is available

### DIFF
--- a/angular-oauth2-oidc/src/interceptors/default-oauth.interceptor.ts
+++ b/angular-oauth2-oidc/src/interceptors/default-oauth.interceptor.ts
@@ -10,7 +10,7 @@ import { OAuthModuleConfig } from "../oauth-module.config";
 
 @Injectable()
 export class DefaultOAuthInterceptor implements HttpInterceptor {
-    
+
     constructor(
         private authStorage: OAuthStorage,
         private errorHandler: OAuthResourceServerErrorHandler,
@@ -24,7 +24,7 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
     }
 
     public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        
+
         let url = req.url.toLowerCase();
 
         if (!this.moduleConfig) return next.handle(req);
@@ -33,16 +33,18 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
         if (!this.checkUrl(url)) return next.handle(req);
 
         let sendAccessToken = this.moduleConfig.resourceServer.sendAccessToken;
-        
+
         if (sendAccessToken) {
 
             let token = this.authStorage.getItem('access_token');
-            let header = 'Bearer ' + token;
 
-            let headers = req.headers
-                                .set('Authorization', header);
+            if (token) {
 
-            req = req.clone({ headers });
+                let header = 'Bearer ' + token;
+                let headers = req.headers.set('Authorization', header);
+
+                req = req.clone({ headers });
+            }
         }
 
         return next.handle(req).pipe(


### PR DESCRIPTION
Avoid calling service with Authorization header with the value "Bearer null"