### PR TITLE
Allow for partial config

### DIFF
--- a/angular-oauth2-oidc/src/auth.config.ts
+++ b/angular-oauth2-oidc/src/auth.config.ts
@@ -201,4 +201,10 @@ export class AuthConfig {
      */
     public skipIssuerCheck? = false;
     
+    constructor(json?: Partial<AuthConfig>) {
+    if (json) {
+      Object.assign(this, json);
+    }
+  }
+    
 }


### PR DESCRIPTION
this allows people who produced configuration files as large objects(why I had to extend auth config with this). To add it as part of the configuration in a type safe way.