### PR TITLE
Set logoutUrl manually if not set in discovery doc.

### DIFF
--- a/angular-oauth2-oidc/src/oauth-service.ts
+++ b/angular-oauth2-oidc/src/oauth-service.ts
@@ -360,7 +360,9 @@ export class OAuthService
                     }
 
                     this.loginUrl = doc.authorization_endpoint;
-                    this.logoutUrl = doc.end_session_endpoint;
+                    if (doc.end_session_endpoint) {
+                        this.logoutUrl = doc.end_session_endpoint;
+                    }
                     this.grantTypesSupported = doc.grant_types_supported;
                     this.issuer = doc.issuer;
                     this.tokenEndpoint = doc.token_endpoint;


### PR DESCRIPTION
Make it possible for developer to set logoutUrl manually if not set in discovery document