### PR TITLE
add missing repository field

### DIFF
--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -5,6 +5,7 @@
     "name": "Manfred Steyer"
   },
   "version": "4.0.1",
+  "repository": "manfredsteyer/angular-oauth2-oidc",
   "dependencies": {
     "jsrsasign": "^8.0.12"
   },


### PR DESCRIPTION
currently npm doesn't link back to the repo/github