### PR TITLE
Improvements for SSR

### DIFF
--- a/projects/lib/src/interceptors/default-oauth.interceptor.ts
+++ b/projects/lib/src/interceptors/default-oauth.interceptor.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, Optional } from '@angular/core';
+import { Injectable, Inject, Optional, PLATFORM_ID } from '@angular/core';
 import { OAuthService } from '../oauth-service';
 import { OAuthStorage } from '../types';
 import {
@@ -13,12 +13,14 @@ import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { OAuthResourceServerErrorHandler } from './resource-server-error-handler';
 import { OAuthModuleConfig } from '../oauth-module.config';
+import { isPlatformBrowser } from '@angular/common';
 
 @Injectable()
 export class DefaultOAuthInterceptor implements HttpInterceptor {
     constructor(
         private authStorage: OAuthStorage,
         private errorHandler: OAuthResourceServerErrorHandler,
+        @Inject(PLATFORM_ID) private platformId: Object,
         @Optional() private moduleConfig: OAuthModuleConfig
     ) { }
 
@@ -33,7 +35,7 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
     ): Observable<HttpEvent<any>> {
         const url = req.url.toLowerCase();
 
-        if (!this.moduleConfig) {
+        if (!isPlatformBrowser(this.platformId) || !this.moduleConfig) {
             return next.handle(req);
         }
         if (!this.moduleConfig.resourceServer) {

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1588,11 +1588,15 @@ export class OAuthService extends AuthConfig {
      * Returns the current access_token.
      */
     public getAccessToken(): string {
-        return this._storage.getItem('access_token');
+        return this._storage
+            ? this._storage.getItem('access_token')
+            : null;
     }
 
     public getRefreshToken(): string {
-        return this._storage.getItem('refresh_token');
+        return this._storage
+            ? this._storage.getItem('refresh_token')
+            : null;
     }
 
     /**


### PR DESCRIPTION
Hi,

I needed to made some improvements for SSR
1) I added check is platform is browser to interceptor because we do not have storage on the server and even if we add some custom storage like variable dictionary it would not get filled after login so basically SSR is unauthorized requests. But this is not a problem because SSR executes only first requests for rendering initial page later angular takes over and calls autorized endpoints with token.

2) I added storage null check for the same reason that we do not have storage on server and there is no point to create on because of reason mentioned above.