### PR TITLE
Make all of the login functions return Promise<boolean>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
-
-.ng_pkg_build
-node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+.ng_pkg_build
+node_modules

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:watch": "npm run docs:build -- -s -w",
     "format": "prettier --single-quote --write projects/**/*.ts",
     "copy:readme": "cpr README.md dist/lib/README.md --overwrite"
-  }, 
+  },
   "private": true,
   "dependencies": {
     "@angular/animations": "6.0.0",
@@ -49,6 +49,7 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.0.51",
     "codelyzer": "~4.0.1",
+    "cpr": "^3.0.1",
     "jasmine-core": "~2.8.0",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~1.7.1",


### PR DESCRIPTION
LoadDiscoveryDocumentAndLogin returned Promise<boolean>, which we liked, so I made the other login functions do the same.  This Improves the flow of the login code for us because you don't need to rely on a callback to determine if the login was successful