### PR TITLE
Support custom grant types

### DIFF
--- a/projects/lib/src/types.ts
+++ b/projects/lib/src/types.ts
@@ -104,6 +104,7 @@ export interface ParsedIdToken {
  * http://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
  */
 export interface TokenResponse {
+  id_token?: string;
   access_token: string;
   token_type: string;
   expires_in: number;


### PR DESCRIPTION
I had the problem that I am using a custom grant type to sign in the user and retrieve id and access token. Right now, grant types other `password` are not supported, so this is an attempt to add support for custom grant types.

The `fetchTokenUsingGrant` function can be used to send a custom grant request to the token endpoint. The logic follows exactly what the `fetchTokenUsingPasswordFlow` does. I actually moved all the logic out of that function, so the password flow is now just a specialization of the custom grant call.

I also added support for the `id_token` in the token response. As [per spec](http://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint), the token endpoint can return the `id_token` as well. For the implementation, I followed the logic of `tryLogin`, except that I’m skipping the additional stuff from the `LoginOptions` (users can always do that manually).

To review the change, best look at the diff with `w=1` in the URL to ignore whitespace changes. To simplify the `http.post` call, I used `toPromise()` to convert the observable into a promise. That avoids having to wrap everything within a Promise constructor (which isn’t the most readable pattern anyway). Unfortunately, that change resulted in a changed indentation, so the diff isn’t that pretty.