### PR TITLE
Add openLogoutUri to add a custom redirect function on logout

### DIFF
--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -231,4 +231,12 @@ export class AuthConfig {
   public openUri?: ((uri: string) => void) = uri => {
     location.href = uri;
   }
+  /**
+   * This property allows you to override the method that is used to open the logout url,
+   * allowing a way for implementations to specify their own method of routing to new
+   * urls.
+   */
+  public openLogoutUri?: ((uri: string) => void) = uri => {
+    location.href = uri;
+  }
 }

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -331,14 +331,14 @@ export class OAuthService extends AuthConfig {
 
     /**
      * DEPRECATED. Use a provider for OAuthStorage instead:
-     * 
+     *
      * { provide: OAuthStorage, useValue: localStorage }
-     * 
+     *
      * Sets a custom storage used to store the received
      * tokens on client side. By default, the browser's
      * sessionStorage is used.
      * @ignore
-     * 
+     *
      * @param storage
      */
     public setStorage(storage: OAuthStorage): void {
@@ -845,7 +845,7 @@ export class OAuthService extends AuthConfig {
         const redirectUri = this.silentRefreshRedirectUri || this.redirectUri;
         this.createLoginUrl(null, null, redirectUri, noPrompt, params).then(url => {
             iframe.setAttribute('src', url);
-            
+
             if (!this.silentRefreshShowIFrame) {
                 iframe.style['display'] = 'none';
             }
@@ -1738,9 +1738,9 @@ export class OAuthService extends AuthConfig {
             logoutUrl =
                 this.logoutUrl +
                 (this.logoutUrl.indexOf('?') > -1 ? '&' : '?') +
-                params.toString()
-        }
-        location.href = logoutUrl;
+                params.toString();
+      }
+      this.config.openLogoutUri(logoutUrl);
     }
 
     /**


### PR DESCRIPTION
I am having an issue when using the logOut function inside a cordova container. The **location.href** call redirects the user to the standard Safari browser. But we are using an InAppBrowser which is called using **window.open**.

Instead of generating the logout Url by myself I want to have a custom function that gets called with the generated logout Url so I can handle it myself. 

If no custom function is set, the standard **location.href** is used.

NOTE: I am aware of the **noRedirectToLogoutUrl** option. But we are using cookies so a request to the server/oauth provider is mandatory so the cookies are cleared properly in the InAppBrowser.

