### PR TITLE
Remove obsolete private method

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -131,11 +131,7 @@ export class OAuthService extends AuthConfig {
         if (this.sessionChecksEnabled) {
             this.setupSessionCheck();
         }
-
-        this.configChanged();
     }
-
-    private configChanged(): void { }
 
     public restartSessionChecksIfStillLoggedIn(): void {
         if (this.hasValidIdToken()) {
@@ -331,19 +327,18 @@ export class OAuthService extends AuthConfig {
 
     /**
      * DEPRECATED. Use a provider for OAuthStorage instead:
-     * 
+     *
      * { provide: OAuthStorage, useValue: localStorage }
-     * 
+     *
      * Sets a custom storage used to store the received
      * tokens on client side. By default, the browser's
      * sessionStorage is used.
      * @ignore
-     * 
+     *
      * @param storage
      */
     public setStorage(storage: OAuthStorage): void {
         this._storage = storage;
-        this.configChanged();
     }
 
     /**
@@ -845,7 +840,7 @@ export class OAuthService extends AuthConfig {
         const redirectUri = this.silentRefreshRedirectUri || this.redirectUri;
         this.createLoginUrl(null, null, redirectUri, noPrompt, params).then(url => {
             iframe.setAttribute('src', url);
-            
+
             if (!this.silentRefreshShowIFrame) {
                 iframe.style['display'] = 'none';
             }


### PR DESCRIPTION
I noted this method was both marked `private`, and not doing anything. I suggest removing it to make the source slightly clearer.