### PR TITLE
Set logout location.href change into an timeout.

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1740,7 +1740,7 @@ export class OAuthService extends AuthConfig {
                 (this.logoutUrl.indexOf('?') > -1 ? '&' : '?') +
                 params.toString()
         }
-        location.href = logoutUrl;
+        setTimeout(function(){ location.href = logoutUrl }, 500);
     }
 
     /**


### PR DESCRIPTION
This will prevent Chrome from canceling this change.