### PR TITLE
Fixes additionalState in Internet Explorer 11

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -92,7 +92,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "sample:build"
+            "browserTarget": "sample:build",
+            "port": 8080
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
As mentioned #390, IE 11 was giving an error when the additionalState was set to a URL containing query parameters (?param1=value&param2=value).
The solution to that was to store the additionalState value into localStorage instead of the oauth state property.