### PR TITLE
Fixing example login flow by requesting 'id_token token' in the auth …

### DIFF
--- a/projects/sample/src/app/auth.config.ts
+++ b/projects/sample/src/app/auth.config.ts
@@ -21,6 +21,8 @@ export const authConfig: AuthConfig = {
 
   // silentRefreshShowIFrame: true,
 
+  responseType: 'id_token token',
+
   showDebugInformation: true,
 
   sessionChecksEnabled: false


### PR DESCRIPTION
@manfredsteyer : In the current version, the sample project / app doesn't work, because the ```responseType``` is not sent correctly. ```id_token token``` needs to be set, for the flow to work.

While this fixes the inability to complete the login flow and read the token / user profile info, the 'requestAccessToken' toggle in the sample app doesn't work. That would need to change / update both the ```responseType``` and the ```requestAccessToken``` flag of the service.

Still, an improvement ;-) 