### PR TITLE
update README re: discovery doc validation disabling

### DIFF
--- a/docs-src/discovery-document-validation.md
+++ b/docs-src/discovery-document-validation.md
@@ -1,0 +1,30 @@
+# Discovery Document Validation
+
+The configuration parameter `strictDiscoveryDocumentValidation` is set `true` by default. This ensures that all of the endpoints provided via the ID Provider discovery document share the same base URL as the `issuer` parameter.
+
+Several ID Providers (i.e. Google OpenID, WS02-IS, PingOne) provide different domains or path params for various endpoints in the discovery document. These providers may still adhere to the [OpenID Connect Provider Configuration specification](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse), but will fail to pass this library's discovery document validation.
+
+To use this library with an ID Provider that does not maintain a consistent base URL across the discovery document endpoints, set the `strictDiscoveryDocumentValidation` parameter to `false` in your configuration:
+
+```TypeScript
+import { AuthConfig } from 'angular-oauth2-oidc';
+
+export const authConfig: AuthConfig = {
+
+  // Url of the Identity Provider
+  issuer: 'https://steyer-identity-server.azurewebsites.net/identity',
+
+  // URL of the SPA to redirect the user to after login
+  redirectUri: window.location.origin + '/index.html',
+
+  // The SPA's id. The SPA is registerd with this id at the auth-server
+  clientId: 'spa-demo',
+
+  // set the scope for the permissions the client should request
+  // The first three are defined by OIDC. The 4th is a usecase-specific one
+  scope: 'openid profile email voucher',
+
+  // turn off validation that discovery document endpoints start with the issuer url defined above
+  strictDiscoveryDocumentValidation: false
+}
+```

--- a/docs-src/implicit-flow-config-discovery.md
+++ b/docs-src/implicit-flow-config-discovery.md
@@ -37,3 +37,5 @@ export class AppComponent {
 
 }
 ```
+
+If you find yourself receiving errors related to discovery document validation, your ID Provider may have OAuth2 endpoints that do not use the `issuer` value as a consistent base URL. You can turn off strict validation of discovery document endpoints for this scenario. See [Discovery Document Validation](https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/discovery-document-validation.html) for details.

--- a/docs-src/summary.json
+++ b/docs-src/summary.json
@@ -48,6 +48,10 @@
         "file": "implicit-flow-config-no-discovery.md"
     },
     {
+        "title": "Using an ID Provider that Fails Discovery Document Validation",
+        "file": "discovery-document-validation.md"
+    },
+    {
         "title": "Using SystemJS",
         "file": "systemjs.md"
     },


### PR DESCRIPTION
As a follow-up to the [closed] issue https://github.com/manfredsteyer/angular-oauth2-oidc/issues/419

Requesting to update the README with instructions for configuring ID Providers that do not have the issuer url as the base for other url's at the discovery endpoint. For these ID Providers, the `strictDiscoveryDocumentValidation` parameter must be set to `false` in order for the library to function.

The discovery document validation is not part of OIDC specification. OIDC Specification states that the Issuer property can optionally contain path components in the uri scheme (https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery)