### PR TITLE
Only present the sendAccessToken interceptor mechanism in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,23 +215,7 @@ This directly redirects the user to the identity server if there are no valid to
 
 ### Calling a Web API with an Access Token
 
-Pass this Header to the used method of the ``Http``-Service within an Instance of the class ``Headers``:
-
-```TypeScript
-var headers = new Headers({
-    "Authorization": "Bearer " + this.oauthService.getAccessToken()
-});
-```
-
-If you are using the new ``HttpClient``, use the class ``HttpHeaders`` instead:
-
-```TypeScript
-var headers = new HttpHeaders({
-    "Authorization": "Bearer " + this.oauthService.getAccessToken()
-});
-```
-
-Since 3.1 you can also automate this task by switching ``sendAccessToken`` on and by setting ``allowedUrls`` to an array with prefixes for the respective URLs. Use lower case for the prefixes.
+You can automate this task by switching ``sendAccessToken`` on and by setting ``allowedUrls`` to an array with prefixes for the respective URLs. Use lower case for the prefixes.
 
 ```TypeScript
 OAuthModule.forRoot({
@@ -241,6 +225,8 @@ OAuthModule.forRoot({
     }
 })
 ```
+
+If you need more versatility, you can look in the [documentation](https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/working-with-httpinterceptors.html) how to setup a custom interceptor.
 
 ## Routing
 


### PR DESCRIPTION
Hello,

Firstly, thank you very much for this awesome library. At my company, we build a lot of Angular applications in an Openid Connect environment and this dependency is a must. Having helped some teams implementing it, when coming to the interceptor part, I discovered that most people use a classic http interceptor and use the first snippet of code for sending the access token.

This is sad because the feature you implemented in the 3.1 version is really great and this white listing mechanism is very convenient and improve the security. I think it deservers to be the only displayed implementation in the Readme, which should focus on a basic setup, and let the documentation display alternative ways, which it already does very well. Also, the 3.1 version has been out for a year and half now and all Angular 4+ projects can use this implementation.

The best would have been to display an https url but the provided url in the snippet display an SSL_ERROR_BAD_CERT_DOMAIN when going on https so I didn't make the change on this.

If you think the classic interceptor should be kept into the Readme, I can udpate my pull request and put it back at second.

I'm looking for any comment that you may think useful.
Kind regards 