### PR TITLE
Added clock skew parameter

### DIFF
--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -216,6 +216,11 @@ export class AuthConfig {
    */
   public useHttpBasicAuthForPasswordFlow? = false;
 
+  /**
+   * The window of time (in seconds) to allow the current time to deviate when validating id_token's iat and exp values.
+   */
+  public clockSkewInSec?: 600;
+
   constructor(json?: Partial<AuthConfig>) {
     if (json) {
       Object.assign(this, json);

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1525,11 +1525,11 @@ export class OAuthService extends AuthConfig {
         const now = Date.now();
         const issuedAtMSec = claims.iat * 1000;
         const expiresAtMSec = claims.exp * 1000;
-        const tenMinutesInMsec = 1000 * 60 * 10;
+        const clockSkewInMSec = (this.clockSkewInSec || 600) * 1000;
 
         if (
-            issuedAtMSec - tenMinutesInMsec >= now ||
-            expiresAtMSec + tenMinutesInMsec <= now
+            issuedAtMSec - clockSkewInMSec >= now ||
+            expiresAtMSec + clockSkewInMSec <= now
         ) {
             const err = 'Token has expired';
             console.error(err);


### PR DESCRIPTION
We needed wider time window when validating token expiration in some test scenarios. We added optional config parameter `clockSkewInSec` which overrides default time window of 10mins.