### PR TITLE
Removed duplicated condition for allowedUrls during interceptor logic and make it optional

### DIFF
--- a/projects/lib/src/interceptors/default-oauth.interceptor.ts
+++ b/projects/lib/src/interceptors/default-oauth.interceptor.ts
@@ -50,7 +50,7 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
     if (!this.moduleConfig.resourceServer) {
       return next.handle(req);
     }
-    if (this.moduleConfig.resourceServer.allowedUrls && !this.checkUrl(url)) {
+    if (!this.checkUrl(url)) {
       return next.handle(req);
     }
 

--- a/projects/lib/src/interceptors/default-oauth.interceptor.ts
+++ b/projects/lib/src/interceptors/default-oauth.interceptor.ts
@@ -44,13 +44,7 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
     const url = req.url.toLowerCase();
 
 
-    if (!this.moduleConfig) {
-      return next.handle(req);
-    }
-    if (!this.moduleConfig.resourceServer) {
-      return next.handle(req);
-    }
-    if (!this.checkUrl(url)) {
+    if (!this.moduleConfig || !this.moduleConfig.resourceServer || !this.checkUrl(url)) {
       return next.handle(req);
     }
 


### PR DESCRIPTION
Before this change user needed to define both `allowedUrls` and `customUrlValidation` to make `customUrlValidation` work, otherwise it was never executed.