### PR TITLE
Validate self when calling crypto provider

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2091,7 +2091,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             let size = 45;
             let id = '';
 
-            const crypto = self.crypto || self['msCrypto'];
+            const crypto = typeof self === 'undefined' ? null : (self.crypto || self['msCrypto']);
             if (crypto) {
                 const bytes = crypto.getRandomValues(new Uint8Array(size));
                 while (0 < size--) {


### PR DESCRIPTION
When generating noonce, SSR is failing due to self not being defined.

Proposing this change to check this and let it fall back when running on the server side.