### PR TITLE
Always set expiration timers for valid token types

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -312,15 +312,11 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     }
 
     protected setupExpirationTimers(): void {
-        const idTokenExp = this.getIdTokenExpiration() || Number.MAX_VALUE;
-        const accessTokenExp = this.getAccessTokenExpiration() || Number.MAX_VALUE;
-        const useAccessTokenExp = accessTokenExp <= idTokenExp;
-
-        if (this.hasValidAccessToken() && useAccessTokenExp) {
+        if (this.hasValidAccessToken()) {
             this.setupAccessTokenTimer();
         }
 
-        if (this.hasValidIdToken() && !useAccessTokenExp) {
+        if (this.hasValidIdToken()) {
             this.setupIdTokenTimer();
         }
     }


### PR DESCRIPTION
Instead of only setting a token expiration timer for the shortest
living token type, set timers for both token types as long as they are
valid.

This solves the remaining issue mentioned by @davdev82 in #432 and #462: If the id token has a shorter lifespan than the access token andyou configure setupAutomaticSilentRefresh to only listen to access token expiration, the token will never be refreshed. Because the filtering of the token expiration of token types now happens in setupAutomaticSilentRefresh(), setupExpirationTimers() should set timers for both token types.

With this commit, the `events` Observable now emits when either the id token or the access token expires (instead of only the one with the shortest lifetime), which is also more complete behavior.