### PR TITLE
Remove "question mark sanitization" when UrlHelperService is parsing hash fragment

### DIFF
--- a/projects/lib/src/url-helper.service.ts
+++ b/projects/lib/src/url-helper.service.ts
@@ -11,13 +11,8 @@ export class UrlHelperService {
       return {};
     }
 
-    const questionMarkPosition = hash.indexOf('?');
+    hash = hash.substr(1);
 
-    if (questionMarkPosition > -1) {
-      hash = hash.substr(questionMarkPosition + 1);
-    } else {
-      hash = hash.substr(1);
-    }
 
     return this.parseQueryString(hash);
   }


### PR DESCRIPTION
Fixes bug where if callback error response contains ?
the split will lose anything prior to the ?
eg
error_uri=https://login.microsoftonline.com/error?code=