### PR TITLE
Allow clockSkewInSec to be different from 600

### DIFF
--- a/docs/classes/AuthConfig.html
+++ b/docs/classes/AuthConfig.html
@@ -444,6 +444,12 @@
                         </span>
                     </td>
                 </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/number" target="_blank" >number</a></code>
+
+                        </td>
+                    </tr>
                         <tr>
                             <td class="col-md-4">
                                     <div class="io-line">Defined in <a href="" data-line="222" class="link-to-prism">projects/lib/src/auth.config.ts:222</a></div>
@@ -2161,7 +2167,7 @@ is triggered after 75% of the token&#39;s life time.</p>
   /**
    * The window of time (in seconds) to allow the current time to deviate when validating id_token&#x27;s iat and exp values.
    */
-  public clockSkewInSec?: 600;
+  public clockSkewInSec?: number;
 
   /**
    * Code Flow is by defauld used together with PKCI which is also higly recommented.

--- a/docs/injectables/OAuthService.html
+++ b/docs/injectables/OAuthService.html
@@ -6176,6 +6176,12 @@ id_tokens.</p>
                         </span>
                     </td>
                 </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/number" target="_blank" >number</a></code>
+
+                        </td>
+                    </tr>
                             <tr>
                                 <td class="col-md-4">
                                     <div class="io-line">Inherited from         <code><a href="../classes/AuthConfig.html" target="_self" >AuthConfig</a></code>

--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -219,7 +219,7 @@ export class AuthConfig {
   /**
    * The window of time (in seconds) to allow the current time to deviate when validating id_token's iat and exp values.
    */
-  public clockSkewInSec?: 600;
+  public clockSkewInSec?: number;
 
   /**
    * Code Flow is by defauld used together with PKCI which is also higly recommented.


### PR DESCRIPTION
Thank you for creating this very easy to use and usefull Angular oidc lib! A very small PR for a small issue, allowing the `clockSkewInSec` from the `AuthConfig`-class to be set to any `number` instead of the literal `600`.