### PR TITLE
Added popup related error handling for implicit grant

### DIFF
--- a/projects/lib/src/events.ts
+++ b/projects/lib/src/events.ts
@@ -20,7 +20,9 @@ export type EventType =
   | 'session_changed'
   | 'session_error'
   | 'session_terminated'
-  | 'logout';
+  | 'logout'
+  | 'popup_closed'
+  | 'popup_blocked';
 
 export abstract class OAuthEvent {
   constructor(readonly type: EventType) {}

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -926,9 +926,26 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             display: 'popup'
         }).then(url => {
             return new Promise((resolve, reject) => {
+              /**
+               * Error handling section
+               */
+                const CheckForPopupClosedInterval = 500;
                 let windowRef = window.open(url, '_blank', this.calculatePopupFeatures(options));
+                let checkForPopupClosedTimer: any;
+                const checkForPopupClosed = () => {
+                  if (!windowRef || windowRef.closed) {
+                    cleanup();
+                    reject(new OAuthErrorEvent('popup_closed',{}));
+                  }
+                };
+                if (!windowRef) {
+                  reject(new OAuthErrorEvent('popup_blocked', {}));
+                } else {
+                  checkForPopupClosedTimer = window.setInterval(checkForPopupClosed, CheckForPopupClosedInterval);
+                }
 
                 const cleanup = () => {
+                    window.clearInterval(checkForPopupClosedTimer);
                     window.removeEventListener('message', listener);
                     windowRef.close();
                     windowRef = null;
@@ -1264,7 +1281,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         }
 
         return url;
-        
+
     }
 
     initImplicitFlowInternal(
@@ -1503,32 +1520,32 @@ export class OAuthService extends AuthConfig implements OnDestroy {
                 (tokenResponse) => {
                     this.debug('refresh tokenResponse', tokenResponse);
                     this.storeAccessTokenResponse(
-                        tokenResponse.access_token, 
-                        tokenResponse.refresh_token, 
+                        tokenResponse.access_token,
+                        tokenResponse.refresh_token,
                         tokenResponse.expires_in,
                         tokenResponse.scope);
 
                     if (this.oidc && tokenResponse.id_token) {
-                        this.processIdToken(tokenResponse.id_token, tokenResponse.access_token).  
+                        this.processIdToken(tokenResponse.id_token, tokenResponse.access_token).
                         then(result => {
                             this.storeIdToken(result);
-            
+
                             this.eventsSubject.next(new OAuthSuccessEvent('token_received'));
                             this.eventsSubject.next(new OAuthSuccessEvent('token_refreshed'));
-            
+
                             resolve(tokenResponse);
                         })
                         .catch(reason => {
                             this.eventsSubject.next(new OAuthErrorEvent('token_validation_error', reason));
                             console.error('Error validating tokens');
                             console.error(reason);
-            
+
                             reject(reason);
                         });
                     } else {
                         this.eventsSubject.next(new OAuthSuccessEvent('token_received'));
                         this.eventsSubject.next(new OAuthSuccessEvent('token_refreshed'));
-            
+
                         resolve(tokenResponse);
                     }
                 },
@@ -1688,7 +1705,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     ): boolean {
         const savedNonce = this._storage.getItem('nonce');
         if (savedNonce !== nonceInState) {
-            
+
             const err = 'Validating access_token failed, wrong state/nonce.';
             console.error(err, savedNonce, nonceInState);
             return false;

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -929,41 +929,46 @@ export class OAuthService extends AuthConfig implements OnDestroy {
               /**
                * Error handling section
                */
-                const CheckForPopupClosedInterval = 500;
+                const checkForPopupClosedInterval = 500;
                 let windowRef = window.open(url, '_blank', this.calculatePopupFeatures(options));
                 let checkForPopupClosedTimer: any;
                 const checkForPopupClosed = () => {
                   if (!windowRef || windowRef.closed) {
                     cleanup();
-                    reject(new OAuthErrorEvent('popup_closed',{}));
+                    reject(new OAuthErrorEvent('popup_closed', {}));
                   }
                 };
                 if (!windowRef) {
                   reject(new OAuthErrorEvent('popup_blocked', {}));
                 } else {
-                  checkForPopupClosedTimer = window.setInterval(checkForPopupClosed, CheckForPopupClosedInterval);
+                  checkForPopupClosedTimer = window.setInterval(checkForPopupClosed, checkForPopupClosedInterval);
                 }
 
                 const cleanup = () => {
                     window.clearInterval(checkForPopupClosedTimer);
                     window.removeEventListener('message', listener);
-                    windowRef.close();
+                    if (windowRef !== null) {
+                      windowRef.close();
+                    }
                     windowRef = null;
                 };
 
                 const listener = (e: MessageEvent) => {
                     const message = this.processMessageEventMessage(e);
-
-                    this.tryLogin({
-                        customHashFragment: message,
-                        preventClearHashAfterLogin: true,
-                    }).then(() => {
-                        cleanup();
-                        resolve();
-                    }, err => {
-                        cleanup();
-                        reject(err);
-                    });
+                    if (message && message !== null) {
+                      this.tryLogin({
+                          customHashFragment: message,
+                          preventClearHashAfterLogin: true,
+                      }).then(() => {
+                          cleanup();
+                          resolve();
+                      }, err => {
+                          cleanup();
+                          reject(err);
+                      });
+                    } else {
+                      console.log('false event firing');
+                    }
                 };
 
                 window.addEventListener('message', listener);


### PR DESCRIPTION
This PR adds code to handle following popup related errors.

1. Popup closed by end user before authentication is done, i.e., before success redirect url is reached, and tokens have arrived to client
2. Popup blocked by browser. This is required because any js based attempt to open popup window will be generally blocked by browser. So for such cases end user should be informed accordingly.