### PR TITLE
Fixed not using config.openUri in code flow

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2168,13 +2168,12 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             throw new Error('loginUrl must use Http. Also check property requireHttps.');
         }
 
-        this.createLoginUrl(additionalState, '', null, false, params).then(function (url) {
-            location.href = url;
-        })
-        .catch(error => {
-            console.error('Error in initAuthorizationCodeFlow');
-            console.error(error);
-        });
+        this.createLoginUrl(additionalState, '', null, false, params)
+            .then(this.config.openUri)
+            .catch(error => {
+                console.error('Error in initAuthorizationCodeFlow');
+                console.error(error);
+            });
     }
 
     protected async createChallangeVerifierPairForPKCE(): Promise<[string, string]> {


### PR DESCRIPTION
Trying to run code+PKCE flow from cordova via in app browser. Implicit flow respecting provided openUri method but code flow not.