### PR TITLE
Clean up more resources in ngOnDestroy

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2073,6 +2073,19 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     public ngOnDestroy() {
         this.clearAccessTokenTimer();
         this.clearIdTokenTimer();
+
+        this.removeSilentRefreshEventListener();
+        const silentRefreshFrame = document.getElementById(this.silentRefreshIFrameName);
+        if(silentRefreshFrame) {
+            silentRefreshFrame.remove();
+        }
+
+        this.stopSessionCheckTimer();
+        this.removeSessionCheckEventListener();
+        const sessionCheckFrame = document.getElementById(this.sessionCheckIFrameName);
+        if(sessionCheckFrame) {
+            sessionCheckFrame.remove();
+        }
     }
 
     protected createNonce(): Promise<string> {


### PR DESCRIPTION
I remove the silent renew and sessioncheck iframes with corresponding message event listeners plus the session check timer

I think this will fix #665, but I might have missed some resources