### PR TITLE
Add public JWT token part decoding API

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1721,6 +1721,13 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     }
 
     /**
+     * Returns the decoded JWT token part.
+     */
+    public decodeTokenPart(part: string): string {
+      return b64DecodeUnicode(this.padBase64(part));
+    }
+
+    /**
      * @ignore
      */
     public processIdToken(
@@ -1729,11 +1736,9 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         skipNonceCheck = false
     ): Promise<ParsedIdToken> {
         const tokenParts = idToken.split('.');
-        const headerBase64 = this.padBase64(tokenParts[0]);
-        const headerJson = b64DecodeUnicode(headerBase64);
+        const headerJson = this.decodeTokenPart(tokenParts[0]);
         const header = JSON.parse(headerJson);
-        const claimsBase64 = this.padBase64(tokenParts[1]);
-        const claimsJson = b64DecodeUnicode(claimsBase64);
+        const claimsJson = this.decodeTokenPart(tokenParts[1]);
         const claims = JSON.parse(claimsJson);
         const savedNonce = this._storage.getItem('nonce');
 


### PR DESCRIPTION
Hey @manfredsteyer,

The important token parsing functions `padBase64` and `b64DecodeUnicode` that you have re-implemented to get rid of fat `jsrsasign` dependency are not available to the outside world. Arguably, it would be even better to provide a generic JWT token part decoding function, which doesn't expose the internal implementation - this function can be then safely used by the consumers of your package to avoid further dependencies like `jwt-decode`.

In this PR I add such an API; one typical use case, which is what we need it for, is to parse access tokens to extract granted scopes. I would appreciate your comments and hopefully this PR can be merged soon!

All the best,
Yury 