### PR TITLE
Set userinfoEndpoint if userinfo_endpoint not exists

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -435,7 +435,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
                     this.grantTypesSupported = doc.grant_types_supported;
                     this.issuer = doc.issuer;
                     this.tokenEndpoint = doc.token_endpoint;
-                    this.userinfoEndpoint = doc.userinfo_endpoint;
+                    this.userinfoEndpoint = doc.userinfo_endpoint || this.userinfoEndpoint;
                     this.jwksUri = doc.jwks_uri;
                     this.sessionCheckIFrameUrl = doc.check_session_iframe || this.sessionCheckIFrameUrl;
 


### PR DESCRIPTION
If userinfo_endpoint not exists in discovery document, update it from auth config field.