### PR TITLE
Fixed not working silent refresh when using 'code'

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1455,7 +1455,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             options.customHashFragment.substring(1) :
             window.location.search;
 
-        const parts = this.getCodePartsFromUrl(window.location.search);
+        const parts = this.getCodePartsFromUrl(querySource);
 
         const code = parts['code'];
         const state = parts['state'];


### PR DESCRIPTION
window.location.search is "" when using the iframe.
The querySource seems to have the correct value

A fix for #600 