### PR TITLE
Support predefined custom parameters extraction from the TokenResponse

### DIFF
--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -65,6 +65,11 @@ export class AuthConfig {
   public tokenEndpoint?: string = null;
 
   /**
+   * Names of known parameters sent out in the TokenResponse. https://tools.ietf.org/html/rfc6749#section-5.1
+   */
+  public customTokenParameters?: string[] = [];
+
+  /**
    * Url of the userinfo endpoint as defined by OpenId Connect.
    */
   public userinfoEndpoint?: string = null;

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2094,12 +2094,12 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     }
 
     /**
-     * Retreive a saved custom property of the TokenReponse object. Only if predefined in authconfig.
+     * Retrieve a saved custom property of the TokenReponse object. Only if predefined in authconfig.
      */
-    public getCustomTokenResponseProperty(property_name): any {
+    public getCustomTokenResponseProperty(requestedProperty: string): any {
       return this._storage && this.config.customTokenParameters
-          && (this.config.customTokenParameters.indexOf(property_name) >= 0)
-            ? this._storage.getItem(property_name) : null;
+          && (this.config.customTokenParameters.indexOf(requestedProperty) >= 0)
+            ? this._storage.getItem(requestedProperty) : null;
     }
 
     /**
@@ -2323,9 +2323,9 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
         const verifier = await this.createNonce();
         const challengeRaw = await this.crypto.calcHash(verifier, 'sha-256');
-        const challange = base64UrlEncode(challengeRaw);
+        const challenge = base64UrlEncode(challengeRaw);
 
-        return [challange, verifier];
+        return [challenge, verifier];
     }
 
     private extractRecognizedCustomParameters(tokenResponse: TokenResponse): any {
@@ -2333,7 +2333,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
           return {};
       }
       let foundParameters: any = {};
-      this.config.customTokenParameters.forEach(recognizedParameter => {
+      this.config.customTokenParameters.forEach((recognizedParameter: string) => {
           if (tokenResponse[recognizedParameter]) {
             foundParameters[recognizedParameter] = tokenResponse[recognizedParameter];
           }

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1403,7 +1403,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         refreshToken: string,
         expiresIn: number,
         grantedScopes: String,
-        customParameters?: any
+        customParameters?: Map<String, String>
     ): void {
         this._storage.setItem('access_token', accessToken);
         if (grantedScopes) {
@@ -1421,8 +1421,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             this._storage.setItem('refresh_token', refreshToken);
         }
         if (customParameters) {
-            Object.keys(customParameters).forEach(key => {
-              this._storage.setItem(key, customParameters[key]);
+            customParameters.forEach((value : string, key: string) => {
+              this._storage.setItem(key, value);
             });
         }
     }
@@ -2099,7 +2099,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     public getCustomTokenResponseProperty(requestedProperty: string): any {
       return this._storage && this.config.customTokenParameters
           && (this.config.customTokenParameters.indexOf(requestedProperty) >= 0)
-            ? this._storage.getItem(requestedProperty) : null;
+            && this._storage.getItem(requestedProperty) !== null
+            ? JSON.parse(this._storage.getItem(requestedProperty)) : null;
     }
 
     /**
@@ -2328,14 +2329,14 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         return [challenge, verifier];
     }
 
-    private extractRecognizedCustomParameters(tokenResponse: TokenResponse): any {
+    private extractRecognizedCustomParameters(tokenResponse: TokenResponse): Map<String, String> {
+      let foundParameters: Map<String, String> = new Map<String, String>();
       if (!this.config.customTokenParameters) {
-          return {};
+        return foundParameters;
       }
-      let foundParameters: any = {};
       this.config.customTokenParameters.forEach((recognizedParameter: string) => {
           if (tokenResponse[recognizedParameter]) {
-            foundParameters[recognizedParameter] = tokenResponse[recognizedParameter];
+            foundParameters.set(recognizedParameter, JSON.stringify(tokenResponse[recognizedParameter]));
           }
       });
       return foundParameters;

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1403,7 +1403,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         refreshToken: string,
         expiresIn: number,
         grantedScopes: String,
-        customParameters?: Map<String, String>
+        customParameters?: Map<string, string>
     ): void {
         this._storage.setItem('access_token', accessToken);
         if (grantedScopes) {
@@ -2331,8 +2331,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         return [challenge, verifier];
     }
 
-    private extractRecognizedCustomParameters(tokenResponse: TokenResponse): Map<String, String> {
-      let foundParameters: Map<String, String> = new Map<String, String>();
+    private extractRecognizedCustomParameters(tokenResponse: TokenResponse): Map<string, string> {
+      let foundParameters: Map<string, string> = new Map<string, string>();
       if (!this.config.customTokenParameters) {
         return foundParameters;
       }

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2131,7 +2131,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         this._storage.removeItem('granted_scopes');
         this._storage.removeItem('session_state');
         if (this.config.customTokenParameters) {
-            return this.config.customTokenParameters.forEach(customParam => this._storage.removeItem(customParam));
+          this.config.customTokenParameters.forEach(customParam => this._storage.removeItem(customParam));
         }
         this.silentRefreshSubject = null;
 

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2130,7 +2130,9 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         this._storage.removeItem('access_token_stored_at');
         this._storage.removeItem('granted_scopes');
         this._storage.removeItem('session_state');
-
+        if (this.config.customTokenParameters) {
+            return this.config.customTokenParameters.forEach(customParam => this._storage.removeItem(customParam));
+        }
         this.silentRefreshSubject = null;
 
         this.eventsSubject.next(new OAuthInfoEvent('logout'));


### PR DESCRIPTION
* Config now supports customTokenParameters for IDP's that send extra properties in their TokenRepsonse
* OAuthService now has an API to retrieve those customParameters
* On logout, remove customParameters from storage

Addresses feature request : https://github.com/manfredsteyer/angular-oauth2-oidc/issues/737