### PR TITLE
fix customHashFragment usage in tryLoginCodeFlow

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1455,7 +1455,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             options.customHashFragment.substring(1) :
             window.location.search;
 
-        const parts = this.getCodePartsFromUrl(window.location.search);
+        const parts = this.getCodePartsFromUrl(querySource);
 
         const code = parts['code'];
         const state = parts['state'];


### PR DESCRIPTION
In tryLoginCodeFlow options.customHashFragment can be passed to override window.location.search in case of a loginFlow running in popup. a querySource const is setup that is assing to that option if set and default to window.location.search but that const was not used to get parts (window.location.search was used instead). This request fix this behavior and correctly use the querySource const.