### PR TITLE
'disableAtHashCheck' by default if responseType is 'id_token'

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2068,7 +2068,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     // addressing https://github.com/manfredsteyer/angular-oauth2-oidc/issues/661
     // i.e. Based on spec the at_hash check is only true for implicit code flow on Ping Federate
     // https://www.pingidentity.com/developer/en/resources/openid-connect-developers-guide.html
-    if (this.hasOwnProperty('responseType') && this.responseType === 'code') {
+    if (this.hasOwnProperty('responseType') && (this.responseType === 'code' || this.responseType === 'id_token')) {
       this.disableAtHashCheck = true;
     }
     if (


### PR DESCRIPTION
If the response type 'id_token' is in the implicit flow, no at_hash value is provided in the id_token. https://github.com/manfredsteyer/angular-oauth2-oidc/issues/789