### PR TITLE
response_types including 'code' gets a code_challenge

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1418,7 +1418,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
       '&scope=' +
       encodeURIComponent(scope);
 
-    if (this.responseType === 'code' && !this.disablePKCE) {
+    if (this.responseType.includes('code') && !this.disablePKCE) {
       const [
         challenge,
         verifier


### PR DESCRIPTION
Every response_Type including 'code' needs a code_challenge. https://github.com/manfredsteyer/angular-oauth2-oidc/issues/804