### PR TITLE
Fix error with ambient type when running Universal

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -102,6 +102,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
   protected inImplicitFlow = false;
 
   protected saveNoncesInLocalStorage = false;
+  private document: Document;
 
   constructor(
     protected ngZone: NgZone,
@@ -112,11 +113,14 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     protected urlHelper: UrlHelperService,
     protected logger: OAuthLogger,
     @Optional() protected crypto: HashHandler,
-    @Inject(DOCUMENT) private document: Document
+    @Inject(DOCUMENT) document: any
   ) {
     super();
 
     this.debug('angular-oauth2-oidc v8-beta');
+
+    // See https://github.com/manfredsteyer/angular-oauth2-oidc/issues/773 for why this is needed
+    this.document = document;
 
     this.discoveryDocumentLoaded$ = this.discoveryDocumentLoadedSubject.asObservable();
     this.events = this.eventsSubject.asObservable();


### PR DESCRIPTION
Hi everyone,

this PR solves issue #773. Since this PR is a bit of a workaround, I wanted to share a few details on what I found on the issue, in case you want to search for a better solution. So please feel free to ignore the following ;-)

With View Engine and [strictMetadataEmit](https://angular.io/guide/angular-compiler-options#strictmetadataemit) enabled, using ambient types did throw a build-time error ([Could not resolve type](https://angular.io/guide/aot-metadata-errors#could-not-resolve-type)), even when correctly injecting a provider with `@Inject()`. Also see issue [https://github.com/angular/angular/issues/20351](https://github.com/angular/angular/issues/20351). This seems to have been fixed with Ivy: [https://github.com/angular/angular/issues/23395#issuecomment-600355368](https://github.com/angular/angular/issues/23395#issuecomment-600355368)

Since Ivy seems to be doing something different here with ambient types, I thought it might be a general problem with a mixed (and correct) setup like the following:
- View Engine lib uses ambient type for constructor param
- App has Ivy enabled
- Running with Universal

Unfortunately, I am not able to reproduce the behaviour with a clean Angular workspace and just that setup. So something else seems to be involved in producing the error. And this is as far as I got for now.

P.S. Having [strictMetadataEmit](https://angular.io/guide/angular-compiler-options#strictmetadataemit) enabled did help me fix this issue, because it throws an error during build-time when using an ambient type. Just wanted to let you know, in case enabling it could help you in your workflow.

Thank you for the great library!