### PR TITLE
Fix SSR ReferenceError with decorator metadata

### DIFF
--- a/projects/lib/tsconfig.lib.json
+++ b/projects/lib/tsconfig.lib.json
@@ -8,7 +8,6 @@
     "declaration": true,
     "sourceMap": true,
     "inlineSources": true,
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "types": [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "downlevelIteration": true,
     "module": "esnext",


### PR DESCRIPTION
Hi again,

like #853 this PR also solves issue #773. After researching a bit more I found a different solution. Because each solution might have different tradeoffs for you, I will leave both PRs open for now. 

I removed the `emitDecoratorMetadata` option, which is only needed for JIT support, if I am not mistaken: https://github.com/angular/angular/issues/30586#issuecomment-494898597. So with Angular 9 it should not be needed.

The actual issue seems to be a TypeScript limitation, but I opened issue https://github.com/angular/angular/issues/37472 with the angular team, to check whether this is a regression to a workaround they have implemented. From that issue you can find more information from the Angular team in linked issues that describe the original problem very well.

Thank you!