### PR TITLE
#877 use sessionCheckIFrameOrigin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "starter",
-  "version": "9.3.0",
+  "version": "10.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -110,6 +110,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
   protected saveNoncesInLocalStorage = false;
   private document: Document;
+  private sessionCheckIFrameOrigin: string;
 
   constructor(
     protected ngZone: NgZone,
@@ -534,6 +535,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
           this.jwksUri = doc.jwks_uri;
           this.sessionCheckIFrameUrl =
             doc.check_session_iframe || this.sessionCheckIFrameUrl;
+          this.sessionCheckIFrameOrigin = new URL(this.sessionCheckIFrameUrl || this.issuer).origin;
 
           this.discoveryDocumentLoaded = true;
           this.discoveryDocumentLoadedSubject.next(doc);
@@ -1361,7 +1363,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     }
 
     const message = this.clientId + ' ' + sessionState;
-    iframe.contentWindow.postMessage(message, this.issuer);
+    iframe.contentWindow.postMessage(message, this.sessionCheckIFrameOrigin);
   }
 
   protected async createLoginUrl(


### PR DESCRIPTION
Suggestion to fix the issue mentioned reported in #877 , please let me know if it looks OK or needs changes.
I'm personally not sure if the fallback to `issuer` is really needed, but at least it would help guarantee backwards compatibility.