### PR TITLE
Changes the link path " Token Refresh"

### DIFF
--- a/docs/additional-documentation/silent-refresh.html
+++ b/docs/additional-documentation/silent-refresh.html
@@ -49,7 +49,7 @@
 
 
 <h2 id="refreshing-when-using-implicit-flow-implicit-flow-and-code-flow">Refreshing when using Implicit Flow (Implicit Flow and Code Flow)</h2>
-<p><strong>Notes for Code Flow</strong>: You can also use this strategy for refreshing tokens when using code flow. However, please note, the strategy described within <a href="./token-refresh.md">Token Refresh</a> is far easier in this case.</p>
+<p><strong>Notes for Code Flow</strong>: You can also use this strategy for refreshing tokens when using code flow. However, please note, the strategy described within <a href="./refreshing-a-token.html">Token Refresh</a> is far easier in this case.</p>
 <p>To refresh your tokens when using implicit flow you can use a silent refresh. This is a well-known solution that compensates the fact that implicit flow does not allow for issuing a refresh token. It uses a hidden iframe to get another token from the auth server. When the user is there still logged in (by using a cookie) it will respond without user interaction and provide new tokens.</p>
 <p>To use this approach, setup a redirect uri for the silent refresh.</p>
 <p>For this, you can set the property silentRefreshRedirectUri in the config object:</p>


### PR DESCRIPTION
Change the link path to the ".html" page instead of ".md". In the path "https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/silent-refresh.html" the "Token Refresh" link is not pointing to the html page.