### PR TITLE
Remove async/await

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2561,11 +2561,9 @@ export class OAuthService extends AuthConfig implements OnDestroy {
       );
     }
 
-    const verifier = await this.createNonce();
-    const challengeRaw = await this.crypto.calcHash(verifier, 'sha-256');
-    const challenge = base64UrlEncode(challengeRaw);
-
-    return [challenge, verifier];
+    return this.createNonce()
+      .then(verifier => ({ verifier, raw: this.crypto.calcHash(verifier, 'sha-256')}))
+      .then(parts => [base64UrlEncode(parts.raw), parts.verifier]);
   }
 
   private extractRecognizedCustomParameters(

--- a/projects/lib/src/token-validation/hash-handler.ts
+++ b/projects/lib/src/token-validation/hash-handler.ts
@@ -12,14 +12,8 @@ export abstract class HashHandler {
 @Injectable()
 export class DefaultHashHandler implements HashHandler {
   async calcHash(valueToHash: string, algorithm: string): Promise<string> {
-    // const encoder = new TextEncoder();
-    // const hashArray = await window.crypto.subtle.digest(algorithm, data);
-    // const data = encoder.encode(valueToHash);
-
     const hashArray = (sha256 as any).array(valueToHash);
-    // const hashString = this.toHashString(hashArray);
     const hashString = this.toHashString2(hashArray);
-
     return hashString;
   }
 
@@ -39,25 +33,4 @@ export class DefaultHashHandler implements HashHandler {
     }
     return result;
   }
-
-  // hexString(buffer) {
-  //     const byteArray = new Uint8Array(buffer);
-  //     const hexCodes = [...byteArray].map(value => {
-  //       const hexCode = value.toString(16);
-  //       const paddedHexCode = hexCode.padStart(2, '0');
-  //       return paddedHexCode;
-  //     });
-
-  //     return hexCodes.join('');
-  //   }
-
-  // toHashString(hexString: string) {
-  //   let result = '';
-  //   for (let i = 0; i < hexString.length; i += 2) {
-  //     let hexDigit = hexString.charAt(i) + hexString.charAt(i + 1);
-  //     let num = parseInt(hexDigit, 16);
-  //     result += String.fromCharCode(num);
-  //   }
-  //   return result;
-  // }
 }


### PR DESCRIPTION
In #329 we said:

> That's why I would prefer to stick with the current (_non async/await, red_) style.

So in #481 naturally someone suggested we'd remove `async`/`await` usages. This PR removes most of it, except the `createLoginUrl` method's usages (as that would touch a whole bunch of lines, I don't want a PR to sit for a couple of months, and likely rack up merge conflicts - so either I'd want to do it when we'd merge it quickly, or perhaps it should be done when preparing a next version).

PS. We could also _kill_ this PR and decide against #329, and start using async/await...