### PR TITLE
Listen for storage to receive auth hash from popup

### DIFF
--- a/projects/sample/src/silent-refresh.html
+++ b/projects/sample/src/silent-refresh.html
@@ -9,7 +9,6 @@
       ];
 
       function isResponse(str) {
-        var count = 0;
         if (!str) return false;
         for (var i = 0; i < checks.length; i++) {
           if (str.match(checks[i])) return true;
@@ -21,7 +20,18 @@
         ? location.hash
         : '#' + location.search;
 
-      (window.opener || window.parent).postMessage(message, location.origin);
+      if (window.parent && window.parent !== window) {
+          // if loaded as an iframe during silent refresh
+          window.parent.postMessage(message, location.origin);
+      } else if (window.opener && window.opener !== window) {
+          // if loaded as a popup during initial login
+          window.opener.postMessage(message, location.origin);
+      } else {
+          // last resort for a popup which has been through redirects and can't use window.opener
+          localStorage.setItem('auth_hash', message);
+          localStorage.removeItem('auth_hash');
+      }
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
Currently, `initLoginFlowInPopup` method is expecting to receive a message from the popup via `postMesage` by subscribing to it via:
```
window.addEventListener('message', listener);
```

Unfortunately this doesn't always work: when the auth provider is on a different domain and the auth process includes redirects within the popup to even more upstream authentication authorities on a third domain and the flow eventually comes back to the original application domain, the popup no longer "remembers" its `window.opener`. [AFAIU this is done for security reasons.](https://stackoverflow.com/a/7120602). This means that the popup has no one to `postMessage` to, and the parent application is left there waiting forever.

This MR suggests adding a storage event fallback. The parent application launches the popup and listens for two sources instead of one: `'message'` events (received by `postMessage` on the other side) and `'storage'` events, which the popup can fallback to if it has no parent or opener to refer to.

Here's an example of the `silent-refresh.html` to support the idea:
```html
<html>
<body>
<script>
    if (window.parent && window.parent !== window) {
        // if loaded as an iframe during silent refresh
        window.parent.postMessage(location.hash, location.origin);
    } else if (window.opener && window.opener !== window) {
        // if loaded as a popup during initial login
        window.opener.postMessage(location.hash, location.origin);
    } else {
        // last resort for a popup which has been through redirects and can't use window.opener
        localStorage.setItem('auth_hash', location.hash);
        localStorage.removeItem('auth_hash');
    }
</script>
</body>
</html>
```
