### PR TITLE
Simplify filtering of truthy tokens

### DIFF
--- a/projects/lib/src/interceptors/default-oauth.interceptor.ts
+++ b/projects/lib/src/interceptors/default-oauth.interceptor.ts
@@ -67,7 +67,7 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
 
     return merge(
       of(this.oAuthService.getAccessToken()).pipe(
-        filter(token => (token ? true : false))
+        filter(token => !!token)
       ),
       this.oAuthService.events.pipe(
         filter(e => e.type === 'token_received'),


### PR DESCRIPTION
Using double not operator (`!!`) instead of conditional expression to filter truthy tokens during http interception.