### PR TITLE
Fix UMD id's related two bugs

### DIFF
--- a/projects/angular-oauth2-oidc-jwks/ng-package.json
+++ b/projects/angular-oauth2-oidc-jwks/ng-package.json
@@ -2,7 +2,12 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/angular-oauth2-oidc-jwks",
   "lib": {
-    "entryFile": "src/public-api.ts"
+    "entryFile": "src/public-api.ts",
+	  "umdId": "angularOauth2OidcJwks",
+	  "umdModuleIds": {
+		  "jsrsasign": "globalThis",
+		  "angular-oauth2-oidc": "angularOauth2Oidc"
+	  }
   },
   "whitelistedNonPeerDependencies": ["jsrsasign"]
 }

--- a/projects/lib/ng-package.json
+++ b/projects/lib/ng-package.json
@@ -4,6 +4,7 @@
   "deleteDestPath": false,
   "lib": {
     "languageLevel": ["dom", "es2017"],
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+	  "umdId": "angularOauth2Oidc"
   }
 }

--- a/projects/lib/ng-package.prod.json
+++ b/projects/lib/ng-package.prod.json
@@ -2,7 +2,8 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/lib",
   "lib": {
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+	  "umdId": "angularOauth2Oidc"
   },
   "whitelistedNonPeerDependencies": [
     "js-sha256"


### PR DESCRIPTION
Currently, no explicit UMD id's are set both for 'angular-oauth2-oidc' & 'angular-oauth2-oidc-jwks'. 
Also the latter package depends on the `jsrsasign` package & neither here no umdModuleId is defined.
When using the UMD bundles you will encounter two bugs. 

[Angular Material had similar issues](https://github.com/angular/angular/issues/35765)

#### Explanation
Since their names contain dashes, the default behaviour of rollup will attach the exports on the window object like this, when the UMD bundles are loaded into the browser:
- `window['angular-oauth2-oidc']` &
- `window['angular-oauth2-oidc-jwks']` accordingly

#### First Bug
The JWKS package depends on the main package. Ng-packagr will try to assume the exported UMD id's, which can be observed in the build log:
![image](https://user-images.githubusercontent.com/5240450/96356455-0611f380-10ef-11eb-9eed-f711d26811c9.png)
**On runtime this will crash**, because the correct id is `window['angular-oauth2-oidc']`

One solution would be to define the umdModuleId in the `ng-packagr.json`
```
"umdModuleIds": {
  "angular-oauth2-oidc": "angular-oauth2-oidc"
}
```
Even though this solves the issue, everyone using UMD must have to set this. To prevent this and also to make the package work with the default behaviour of ng-packagr, this PR changes the UMD id to it's camelCased version. ('angularOauth2Oidc' & 'angularOauth2OidcJwks')

#### Second Bug
The second bug is caused due the dependency to `jsrsasign`. Also the author does not provide an UMD bundle, but instead exports everything globally. Ng-packagr however, assumes that the umdModuleId would be `rs`:
![image](https://user-images.githubusercontent.com/5240450/96356556-766d4480-10f0-11eb-8030-37d0efe97bbb.png)
**But they are available on the window / globalThis object**. To mitigate this issue, we can tell ng-packagr the umdModuleId for that package would be `globalThis`, which solves the issue.
