### PR TITLE
fix: multiplying calls to token endpoint in code flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "starter",
-  "version": "9.3.0",
+  "version": "10.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -102,6 +102,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
   protected accessTokenTimeoutSubscription: Subscription;
   protected idTokenTimeoutSubscription: Subscription;
   protected tokenReceivedSubscription: Subscription;
+  protected automaticRefreshSubscription: Subscription;
   protected sessionCheckEventListener: EventListener;
   protected jwksUri: string;
   protected sessionCheckTimer: any;
@@ -222,7 +223,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     noPrompt = true
   ): void {
     let shouldRunSilentRefresh = true;
-    this.events
+    this.clearAutomaticRefreshTimer();
+    this.automaticRefreshSubscription = this.events
       .pipe(
         tap(e => {
           if (e.type === 'token_received') {
@@ -448,6 +450,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
   public stopAutomaticRefresh() {
     this.clearAccessTokenTimer();
     this.clearIdTokenTimer();
+    this.clearAutomaticRefreshTimer();
   }
 
   protected clearAccessTokenTimer(): void {
@@ -459,6 +462,12 @@ export class OAuthService extends AuthConfig implements OnDestroy {
   protected clearIdTokenTimer(): void {
     if (this.idTokenTimeoutSubscription) {
       this.idTokenTimeoutSubscription.unsubscribe();
+    }
+  }
+
+  protected clearAutomaticRefreshTimer(): void {
+    if (this.automaticRefreshSubscription) {
+      this.automaticRefreshSubscription.unsubscribe();
     }
   }
 

--- a/projects/sample/src/app/home/home.component.html
+++ b/projects/sample/src/app/home/home.component.html
@@ -109,5 +109,13 @@
     <button class="btn btn-default" (click)="loadUserProfile()">
       Load User Profile
     </button>
+
+    <button class="btn btn-default" (click)="startAutomaticRefresh()">
+      Start automatic refresh
+    </button>
+
+    <button class="btn btn-default" (click)="stopAutomaticRefresh()">
+      Stop automatic refresh
+    </button>
   </div>
 </div>

--- a/projects/sample/src/app/home/home.component.ts
+++ b/projects/sample/src/app/home/home.component.ts
@@ -86,6 +86,14 @@ export class HomeComponent implements OnInit {
     this.oauthService.loadUserProfile().then(up => (this.userProfile = up));
   }
 
+  startAutomaticRefresh(): void {
+    this.oauthService.setupAutomaticSilentRefresh();
+  }
+
+  stopAutomaticRefresh(): void {
+    this.oauthService.stopAutomaticRefresh();
+  }
+
   get givenName() {
     var claims = this.oauthService.getIdentityClaims();
     if (!claims) return null;


### PR DESCRIPTION
As of now, when stopping the automatic refresh in code flow and starting it again, calls to the token endpoint will start multiplying. Depending on the timing some will get rejected based on already used refresh token. 

Managed to track it down to the subscription from events in setupAutomaticSilentRefresh not being unsubscribed together with the other timers.