### PR TITLE
Removed lower-case transformation on URL

### DIFF
--- a/projects/lib/src/interceptors/default-oauth.interceptor.ts
+++ b/projects/lib/src/interceptors/default-oauth.interceptor.ts
@@ -47,7 +47,7 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
     req: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    const url = req.url.toLowerCase();
+    const url: string = req.url;
 
     if (
       !this.moduleConfig ||


### PR DESCRIPTION
Resolves #974 

The side effect of this fix is that URLs are now case-sensitive. 

