### PR TITLE
fix: listenTo param of `setupAutomaticSilentRefresh`

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -231,15 +231,11 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             shouldRunSilentRefresh = false;
           }
         }),
-        filter(e => e.type === 'token_expires'),
+        filter((e: OAuthInfoEvent) => e.type === 'token_expires' && (listenTo == null || listenTo === 'any' || e.info === listenTo)),
         debounceTime(1000)
       )
-      .subscribe(e => {
-        const event = e as OAuthInfoEvent;
-        if (
-          (listenTo == null || listenTo === 'any' || event.info === listenTo) &&
-          shouldRunSilentRefresh
-        ) {
+      .subscribe(_ => {
+        if (shouldRunSilentRefresh) {
           // this.silentRefresh(params, noPrompt).catch(_ => {
           this.refreshInternal(params, noPrompt).catch(_ => {
             this.debug('Automatic silent refresh did not work');


### PR DESCRIPTION
Checking listenTo after debounceTime can sometimes wrong because the debounceTime can return either access_token or id_token.

It is quite hard to reproduce this bug, depends on the sequence of events of the expired access_token and id_token. Sometimes it is in a different order and causes checking the listenTo after `debounceTime` wrong.

Ref: https://rxjs-dev.firebaseapp.com/api/operators/debounceTime