### PR TITLE
Use configured revocationEndpoint by default

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -537,7 +537,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
           this.discoveryDocumentLoaded = true;
           this.discoveryDocumentLoadedSubject.next(doc);
-          this.revocationEndpoint = doc.revocation_endpoint;
+          this.revocationEndpoint = doc.revocation_endpoint || this.revocationEndpoint;
 
           if (this.sessionChecksEnabled) {
             this.restartSessionChecksIfStillLoggedIn();


### PR DESCRIPTION
In case revocation_endpoint is not present in the openid configuration, the user provided revocationEndpoint should be used by default.
Otherwise the openid configuration will overwrite it to undefined regardlessly, and the user provided revocationEndpoint is not used at all.