### PR TITLE
feat: process eventual id token during password flow

### DIFF
--- a/docs/injectables/OAuthService.html
+++ b/docs/injectables/OAuthService.html
@@ -1020,8 +1020,8 @@ password flow.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2301"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2301</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2259"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2259</a></div>
                 </td>
             </tr>
 
@@ -1148,8 +1148,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1136"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1136</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1085"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1085</a></div>
                 </td>
             </tr>
 
@@ -1220,8 +1220,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1545"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1545</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1494"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1494</a></div>
                 </td>
             </tr>
 
@@ -1292,8 +1292,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1169"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1169</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1118"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1118</a></div>
                 </td>
             </tr>
 
@@ -1334,8 +1334,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2494"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2494</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2452"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2452</a></div>
                 </td>
             </tr>
 
@@ -1406,8 +1406,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1345"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1345</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1294"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1294</a></div>
                 </td>
             </tr>
 
@@ -1447,8 +1447,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2504"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2504</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2462"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2462</a></div>
                 </td>
             </tr>
 
@@ -1722,8 +1722,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2555"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2555</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2513"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2513</a></div>
                 </td>
             </tr>
 
@@ -1764,8 +1764,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1367"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1367</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1316"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1316</a></div>
                 </td>
             </tr>
 
@@ -1899,8 +1899,8 @@ to transmit the access_token to a service</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2452"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2452</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2410"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2410</a></div>
                 </td>
             </tr>
 
@@ -2005,22 +2005,22 @@ to transmit the access_token to a service</p>
             <tr>
                 <td class="col-md-4">
                     <span class="modifier-icon icon ion-ios-reset"></span>
-                    <code>fetchTokenUsingPasswordFlow(userName: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank">string</a>, password: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank">string</a>, headers: <a href="https://angular.io/api/common/http/HttpHeaders" target="_blank">HttpHeaders</a>)</code>
+                    <code>fetchTokenUsingPasswordFlow(userName: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank">string</a>, password: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank">string</a>, headers: <a href="https://angular.io/api/common/http/HttpHeaders" target="_blank">HttpHeaders</a>, skipNonceCheck)</code>
                 </td>
             </tr>
 
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="775"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:775</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="776"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:776</a></div>
                 </td>
             </tr>
 
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-description"><p>Uses password flow to exchange userName and password for an access_token.</p>
+                    <div class="io-description"><p>Uses password flow to exchange userName and password for an token.</p>
 </div>
 
                     <div class="io-description">
@@ -2084,6 +2084,24 @@ to transmit the access_token to a service</p>
 
                                     <td>
                                         <p>Optional additional http-headers.</p>
+
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>skipNonceCheck</td>
+                                    <td>
+                                    </td>
+
+                                    <td>
+                                        No
+                                    </td>
+
+                                    <td>
+                                        <code>false</code>
+                                    </td>
+
+                                    <td>
+                                        <p>Skips nonce check for an eventual id token</p>
 
                                     </td>
                                 </tr>
@@ -2248,8 +2266,8 @@ fail.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2212"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2212</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2170"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2170</a></div>
                 </td>
             </tr>
 
@@ -2291,8 +2309,8 @@ fail.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2224"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2224</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2182"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2182</a></div>
                 </td>
             </tr>
 
@@ -2335,8 +2353,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2231"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2231</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2189"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2189</a></div>
                 </td>
             </tr>
 
@@ -2376,8 +2394,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2288"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2288</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2246"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2246</a></div>
                 </td>
             </tr>
 
@@ -2450,8 +2468,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2187"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2187</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2145"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2145</a></div>
                 </td>
             </tr>
 
@@ -2493,8 +2511,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2176"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2176</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2134"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2134</a></div>
                 </td>
             </tr>
 
@@ -2536,8 +2554,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2198"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2198</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2156"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2156</a></div>
                 </td>
             </tr>
 
@@ -2579,8 +2597,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2243"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2243</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2201"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2201</a></div>
                 </td>
             </tr>
 
@@ -2623,8 +2641,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2235"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2235</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2193"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2193</a></div>
                 </td>
             </tr>
 
@@ -2664,8 +2682,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2216"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2216</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2174"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2174</a></div>
                 </td>
             </tr>
 
@@ -2705,8 +2723,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1983"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1983</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1941"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1941</a></div>
                 </td>
             </tr>
 
@@ -2746,8 +2764,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1987"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1987</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1945"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1945</a></div>
                 </td>
             </tr>
 
@@ -2830,8 +2848,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1246"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1246</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1195"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1195</a></div>
                 </td>
             </tr>
 
@@ -2871,8 +2889,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1291"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1291</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1240"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1240</a></div>
                 </td>
             </tr>
 
@@ -2912,8 +2930,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1242"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1242</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1191"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1191</a></div>
                 </td>
             </tr>
 
@@ -2953,8 +2971,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2254"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2254</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2212"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2212</a></div>
                 </td>
             </tr>
 
@@ -2996,8 +3014,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2271"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2271</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2229"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2229</a></div>
                 </td>
             </tr>
 
@@ -3039,8 +3057,8 @@ as milliseconds since 1970.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2530"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2530</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2488"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2488</a></div>
                 </td>
             </tr>
 
@@ -3133,8 +3151,8 @@ the auth servers login url.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1523"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1523</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1472"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1472</a></div>
                 </td>
             </tr>
 
@@ -3238,8 +3256,8 @@ parameter loginHint (for the sake of compatibility with former versions)</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1055"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1055</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1004"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1004</a></div>
                 </td>
             </tr>
 
@@ -3312,8 +3330,8 @@ and implicit flows.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1481"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1481</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1430"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1430</a></div>
                 </td>
             </tr>
 
@@ -3403,8 +3421,8 @@ and implicit flows.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2518"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2518</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2476"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2476</a></div>
                 </td>
             </tr>
 
@@ -3497,8 +3515,8 @@ depending on your configuration.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1062"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1062</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1011"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1011</a></div>
                 </td>
             </tr>
 
@@ -3569,8 +3587,8 @@ depending on your configuration.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1303"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1303</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1252"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1252</a></div>
                 </td>
             </tr>
 
@@ -3944,8 +3962,8 @@ Otherwise stricter validations take place that make this operation fail.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2312"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2312</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2270"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2270</a></div>
                 </td>
             </tr>
 
@@ -3989,8 +4007,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2313"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2313</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2271"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2271</a></div>
                 </td>
             </tr>
 
@@ -4061,8 +4079,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2314"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2314</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2272"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2272</a></div>
                 </td>
             </tr>
 
@@ -4133,8 +4151,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2315"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2315</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2273"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2273</a></div>
                 </td>
             </tr>
 
@@ -4217,8 +4235,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2316"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2316</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2274"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2274</a></div>
                 </td>
             </tr>
 
@@ -4308,8 +4326,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2202"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2202</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2160"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2160</a></div>
                 </td>
             </tr>
 
@@ -4376,8 +4394,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1149"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1149</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1098"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1098</a></div>
                 </td>
             </tr>
 
@@ -4525,8 +4543,8 @@ redirected to it with optional state parameter.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="855"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:855</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="804"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:804</a></div>
                 </td>
             </tr>
 
@@ -4572,8 +4590,8 @@ method silentRefresh.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1296"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1296</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1245"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1245</a></div>
                 </td>
             </tr>
 
@@ -4613,8 +4631,8 @@ method silentRefresh.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="938"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:938</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="887"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:887</a></div>
                 </td>
             </tr>
 
@@ -4654,8 +4672,8 @@ method silentRefresh.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1541"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1541</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1490"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1490</a></div>
                 </td>
             </tr>
 
@@ -4779,8 +4797,8 @@ method silentRefresh.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="2594"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:2594</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="2552"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:2552</a></div>
                 </td>
             </tr>
 
@@ -5198,8 +5216,8 @@ logged back in via receiving a new token.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1193"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1193</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1142"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1142</a></div>
                 </td>
             </tr>
 
@@ -5239,8 +5257,8 @@ logged back in via receiving a new token.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="948"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:948</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="897"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:897</a></div>
                 </td>
             </tr>
 
@@ -5280,8 +5298,8 @@ logged back in via receiving a new token.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="972"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:972</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="921"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:921</a></div>
                 </td>
             </tr>
 
@@ -5374,8 +5392,8 @@ the existing tokens expire.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1328"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1328</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1277"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1277</a></div>
                 </td>
             </tr>
 
@@ -5459,8 +5477,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1338"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1338</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1287"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1287</a></div>
                 </td>
             </tr>
 
@@ -5500,8 +5518,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1558"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1558</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1507"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1507</a></div>
                 </td>
             </tr>
 
@@ -5620,8 +5638,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1972"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1972</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1930"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1930</a></div>
                 </td>
             </tr>
 
@@ -5692,8 +5710,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1979"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1979</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1937"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1937</a></div>
                 </td>
             </tr>
 
@@ -5764,8 +5782,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1597"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1597</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1546"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1546</a></div>
                 </td>
             </tr>
 
@@ -5847,8 +5865,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1617"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1617</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1566"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1566</a></div>
                 </td>
             </tr>
 
@@ -5923,8 +5941,8 @@ To restart it, call setupAutomaticSilentRefresh again.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1819"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1819</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1777"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1777</a></div>
                 </td>
             </tr>
 
@@ -6081,8 +6099,8 @@ current client.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1952"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1952</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1910"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1910</a></div>
                 </td>
             </tr>
 
@@ -6369,8 +6387,8 @@ current client.</p>
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="1271"
-                            class="link-to-prism">projects/lib/src/oauth-service.ts:1271</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="1220"
+                            class="link-to-prism">projects/lib/src/oauth-service.ts:1220</a></div>
                 </td>
             </tr>
 
@@ -9741,82 +9759,31 @@ export class OAuthService extends AuthConfig implements OnDestroy {
   }
 
   /**
-   * Uses password flow to exchange userName and password for an access_token.
+   * Uses password flow to exchange userName and password for an token.
    * @param userName
    * @param password
    * @param headers Optional additional http-headers.
+   * @param skipNonceCheck Skips nonce check for an eventual id token
    */
   public fetchTokenUsingPasswordFlow(
     userName: string,
     password: string,
-    headers: HttpHeaders &#x3D; new HttpHeaders()
+    headers: HttpHeaders &#x3D; new HttpHeaders(),
+    skipNonceCheck &#x3D; false
   ): Promise&lt;TokenResponse&gt; {
-    this.assertUrlNotNullAndCorrectProtocol(
-      this.tokenEndpoint,
-      &#x27;tokenEndpoint&#x27;
-    );
+    /**
+     * A &#x60;HttpParameterCodec&#x60; that uses &#x60;encodeURIComponent&#x60; and &#x60;decodeURIComponent&#x60; to
+     * serialize and parse URL parameter keys and values.
+     *
+     * @stable
+     */
+    let params &#x3D; new HttpParams({ encoder: new WebHttpUrlEncodingCodec() })
+      .set(&#x27;grant_type&#x27;, &#x27;password&#x27;)
+      .set(&#x27;scope&#x27;, this.scope)
+      .set(&#x27;username&#x27;, userName)
+      .set(&#x27;password&#x27;, password);
 
-    return new Promise((resolve, reject) &#x3D;&gt; {
-      /**
-       * A &#x60;HttpParameterCodec&#x60; that uses &#x60;encodeURIComponent&#x60; and &#x60;decodeURIComponent&#x60; to
-       * serialize and parse URL parameter keys and values.
-       *
-       * @stable
-       */
-      let params &#x3D; new HttpParams({ encoder: new WebHttpUrlEncodingCodec() })
-        .set(&#x27;grant_type&#x27;, &#x27;password&#x27;)
-        .set(&#x27;scope&#x27;, this.scope)
-        .set(&#x27;username&#x27;, userName)
-        .set(&#x27;password&#x27;, password);
-
-      if (this.useHttpBasicAuth) {
-        const header &#x3D; btoa(&#x60;${this.clientId}:${this.dummyClientSecret}&#x60;);
-        headers &#x3D; headers.set(&#x27;Authorization&#x27;, &#x27;Basic &#x27; + header);
-      }
-
-      if (!this.useHttpBasicAuth) {
-        params &#x3D; params.set(&#x27;client_id&#x27;, this.clientId);
-      }
-
-      if (!this.useHttpBasicAuth &amp;&amp; this.dummyClientSecret) {
-        params &#x3D; params.set(&#x27;client_secret&#x27;, this.dummyClientSecret);
-      }
-
-      if (this.customQueryParams) {
-        for (const key of Object.getOwnPropertyNames(this.customQueryParams)) {
-          params &#x3D; params.set(key, this.customQueryParams[key]);
-        }
-      }
-
-      headers &#x3D; headers.set(
-        &#x27;Content-Type&#x27;,
-        &#x27;application/x-www-form-urlencoded&#x27;
-      );
-
-      this.http
-        .post&lt;TokenResponse&gt;(this.tokenEndpoint, params, { headers })
-        .subscribe(
-          tokenResponse &#x3D;&gt; {
-            this.debug(&#x27;tokenResponse&#x27;, tokenResponse);
-            this.storeAccessTokenResponse(
-              tokenResponse.access_token,
-              tokenResponse.refresh_token,
-              tokenResponse.expires_in ||
-                this.fallbackAccessTokenExpirationTimeInSec,
-              tokenResponse.scope,
-              this.extractRecognizedCustomParameters(tokenResponse)
-            );
-
-            this.eventsSubject.next(new OAuthSuccessEvent(&#x27;token_received&#x27;));
-            resolve(tokenResponse);
-          },
-          err &#x3D;&gt; {
-            this.logger.error(&#x27;Error performing password flow&#x27;, err);
-            this.eventsSubject.next(new OAuthErrorEvent(&#x27;token_error&#x27;, err));
-            reject(err);
-          }
-        );
-    });
+    return this.fetchAndProcessToken(params, headers, skipNonceCheck);
   }
 
   /**
@@ -10694,15 +10661,17 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     return this.fetchAndProcessToken(params);
   }
 
-  private fetchAndProcessToken(params: HttpParams): Promise&lt;TokenResponse&gt; {
+  private fetchAndProcessToken(
+    params: HttpParams,
+    headers: HttpHeaders &#x3D; new HttpHeaders(),
+    skipNonceCheck &#x3D; false
+  ): Promise&lt;TokenResponse&gt; {
     this.assertUrlNotNullAndCorrectProtocol(
       this.tokenEndpoint,
       &#x27;tokenEndpoint&#x27;
     );
-    let headers &#x3D; new HttpHeaders().set(
-      &#x27;Content-Type&#x27;,
-      &#x27;application/x-www-form-urlencoded&#x27;
-    );
+
+    headers &#x3D; headers.set(&#x27;Content-Type&#x27;, &#x27;application/x-www-form-urlencoded&#x27;);
 
     if (this.useHttpBasicAuth) {
       const header &#x3D; btoa(&#x60;${this.clientId}:${this.dummyClientSecret}&#x60;);
@@ -10717,18 +10686,18 @@ export class OAuthService extends AuthConfig implements OnDestroy {
       params &#x3D; params.set(&#x27;client_secret&#x27;, this.dummyClientSecret);
     }
 
-    return new Promise((resolve, reject) &#x3D;&gt; {
-      if (this.customQueryParams) {
-        for (let key of Object.getOwnPropertyNames(this.customQueryParams)) {
-          params &#x3D; params.set(key, this.customQueryParams[key]);
-        }
+    if (this.customQueryParams) {
+      for (let key of Object.getOwnPropertyNames(this.customQueryParams)) {
+        params &#x3D; params.set(key, this.customQueryParams[key]);
       }
+    }
 
+    return new Promise((resolve, reject) &#x3D;&gt; {
       this.http
         .post&lt;TokenResponse&gt;(this.tokenEndpoint, params, { headers })
         .subscribe(
           tokenResponse &#x3D;&gt; {
-            this.debug(&#x27;refresh tokenResponse&#x27;, tokenResponse);
+            this.debug(&#x27;tokenResponse&#x27;, tokenResponse);
             this.storeAccessTokenResponse(
               tokenResponse.access_token,
               tokenResponse.refresh_token,
@@ -10741,7 +10710,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             if (this.oidc &amp;&amp; tokenResponse.id_token) {
               this.processIdToken(
                 tokenResponse.id_token,
-                tokenResponse.access_token
+                tokenResponse.access_token,
+                skipNonceCheck
               )
                 .then(result &#x3D;&gt; {
                   this.storeIdToken(result);
@@ -10772,10 +10742,16 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             }
           },
           err &#x3D;&gt; {
+            // TODO: decide which version is correct
+            // --- password flow
+            this.logger.error(&#x27;Error performing password flow&#x27;, err);
+            this.eventsSubject.next(new OAuthErrorEvent(&#x27;token_error&#x27;, err));
+            // --- code flow
             console.error(&#x27;Error getting token&#x27;, err);
             this.eventsSubject.next(
               new OAuthErrorEvent(&#x27;token_refresh_error&#x27;, err)
             );
+            // ---
             reject(err);
           }
         );


### PR DESCRIPTION
During password flow (`fetchTokenUsingPasswordFlow`) the resulting token response can contain an id token (e.g. Keycloak) that isn't processed currently.  

With this PR `fetchTokenUsingPasswordFlow` uses the same token processing as `getTokenFromCode` and handles the id token if it is present.