### PR TITLE
fix: #728

### DIFF
--- a/projects/sample/src/app/app.component.ts
+++ b/projects/sample/src/app/app.component.ts
@@ -45,7 +45,6 @@ export class AppComponent {
 
   private configureImplicitFlow() {
     this.oauthService.configure(authConfig);
-    this.oauthService.setStorage(localStorage);
     // this.oauthService.tokenValidationHandler = new JwksValidationHandler();
 
     this.oauthService.loadDiscoveryDocumentAndTryLogin().then(_ => {


### PR DESCRIPTION
Use same storage regardless of flow in sample

The "smart" way to select a different storage type in the sample
was causing issues. Sometimes the `setStorage(localStorage)` call
would be made just before the _first_ time someone uses Code Flow
which after the redirect causes the app to look in `sessionStorage`
for the nonce (which it wont find as the initiation of Code Flow
still used the localStorage).

This fix changes it to always use the same storage type, which gives
more reliable results. (I did consider further tweaking the "smart"
way to select the right storage, but it's super hard to predict in
which order(s) users will swap between flow types in the sample).

See also: https://github.com/manfredsteyer/angular-oauth2-oidc/issues/728#issuecomment-808969225

Fixes #728