### PR TITLE
fix(jwks): update jsrsasign dependency to 10.2.0

### DIFF
--- a/projects/angular-oauth2-oidc-jwks/package.json
+++ b/projects/angular-oauth2-oidc-jwks/package.json
@@ -2,7 +2,7 @@
   "name": "angular-oauth2-oidc-jwks",
   "version": "10.0.0",
   "dependencies": {
-    "jsrsasign": "^8.0.12"
-  ,    "tslib": "^2.0.0"
-}
+    "jsrsasign": "^10.2.0",
+    "tslib": "^2.0.0"
+  }
 }


### PR DESCRIPTION
Solves security vulnerability in angular-oauth2-oidc-jwks.

Closes #1061.