### PR TITLE
Add check for localStorage writeability

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -162,10 +162,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     }
 
     // in IE, sessionStorage does not always survive a redirect
-    if (
-      typeof window !== 'undefined' &&
-      typeof window['localStorage'] !== 'undefined'
-    ) {
+    if (this.checkLocalStorageAccessable()) {
       const ua = window?.navigator?.userAgent;
       const msie = ua?.includes('MSIE ') || ua?.includes('Trident');
 
@@ -175,6 +172,23 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     }
 
     this.setupRefreshTimer();
+  }
+
+  private checkLocalStorageAccessable(){
+    if(typeof window === 'undefined')
+      return false;
+
+    const test = 'test';
+    try {
+      if(typeof window['localStorage'] === 'undefined')
+        return false;
+
+      localStorage.setItem(test, test);
+      localStorage.removeItem(test);
+      return true;
+    } catch(e) {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Issue:
Running the library as a third-party (eg. inside an iFrame) when third-party cookies are disabled (as is starting to be default setting in browsers) or cookies disabled, also disables access to localStorage. This can be worked around by providing a custom storage in configuration, but it still breaks because the check for setting saveNoncesInLocalStorage breaks at `typeof window['localStorage'] !== 'undefined'` due to access issues.

Fix:
Do the check inside try/catch.
![image](https://user-images.githubusercontent.com/1439413/127452508-0e1371ed-5425-46f7-b1cb-beda299634eb.png)
