### PR TITLE
Preserve requested route for code flow

### DIFF
--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -257,6 +257,12 @@ export class AuthConfig {
    */
   public disablePKCE? = false;
 
+  /**
+   * Set this to true to preserve the requested route including query parameters after code flow login.
+   * This setting enables deep linking for the code flow.
+   */
+  public preserveRequestedRoute? = false;
+
   constructor(json?: Partial<AuthConfig>) {
     if (json) {
       Object.assign(this, json);


### PR DESCRIPTION
I added a new option `preserveRequestedRoute` which is `false` by default.
If set to true and when using the code flow, the requested route and query params are stored to storage and after successful token retrieval used to redirect to. This feature enables deep linking.
Fixes #592 