### PR TITLE
docs: fix broken link in silent-refresh documentation pointing to token-refresh

### DIFF
--- a/docs-src/silent-refresh.md
+++ b/docs-src/silent-refresh.md
@@ -1,6 +1,6 @@
 ## Refreshing when using Implicit Flow (Implicit Flow and Code Flow)
 
-**Notes for Code Flow**: You can also use this strategy for refreshing tokens when using code flow. However, please note, the strategy described within [Token Refresh](./token-refresh.md) is far easier in this case.
+**Notes for Code Flow**: You can also use this strategy for refreshing tokens when using code flow. However, please note, the strategy described within [Token Refresh](./token-refresh.html) is far easier in this case.
 
 To refresh your tokens when using implicit flow you can use a silent refresh. This is a well-known solution that compensates the fact that implicit flow does not allow for issuing a refresh token. It uses a hidden iframe to get another token from the auth server. When the user is there still logged in (by using a cookie) it will respond without user interaction and provide new tokens.
 

--- a/docs-src/summary.json
+++ b/docs-src/summary.json
@@ -15,7 +15,10 @@
         "title": "Silent Refresh",
         "file": "silent-refresh.md"
     },
-
+    {
+        "title": "Token Refresh",
+        "file": "token-refresh.md"
+    },
     {
         "title": "Working with HttpInterceptors",
         "file": "interceptors.md"


### PR DESCRIPTION
This PR targets issue #1129.

I hope this PR is fine (was not totally sure about the contribution guidelines).

It's my first PR to OS so please be patient with me 😛 