### PR TITLE
add new AuthConfig/discoveryDoc behavior for urls

### DIFF
--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -145,6 +145,14 @@ export class AuthConfig {
   public strictDiscoveryDocumentValidation? = true;
 
   /**
+   * Set this to true to force overwrite of discovery
+   * document urls with config parameters instead of
+   * using config parameters as fallback if discovery
+   * document urls are missing
+   */
+  public overwriteDiscoveryDocumentUrls? = false;
+
+  /**
    * JSON Web Key Set (https://tools.ietf.org/html/rfc7517)
    * with keys used to validate received id_tokens.
    * This is taken out of the disovery document. Can be set manually too.

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -553,20 +553,38 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             return;
           }
 
-          this.loginUrl = doc.authorization_endpoint;
-          this.logoutUrl = doc.end_session_endpoint || this.logoutUrl;
+          this.loginUrl = this.overwriteDiscoveryDocumentUrls ?
+            this.loginUrl || doc.authorization_endpoint :
+            doc.authorization_endpoint || this.loginUrl;
+
+          this.logoutUrl = this.overwriteDiscoveryDocumentUrls ?
+            this.logoutUrl || doc.end_session_endpoint :
+            doc.end_session_endpoint || this.logoutUrl;
+
           this.grantTypesSupported = doc.grant_types_supported;
+
           this.issuer = doc.issuer;
-          this.tokenEndpoint = doc.token_endpoint;
-          this.userinfoEndpoint =
+
+          this.tokenEndpoint = this.overwriteDiscoveryDocumentUrls ?
+            this.tokenEndpoint || doc.token_endpoint :
+            doc.token_endpoint || this.tokenEndpoint;
+
+          this.userinfoEndpoint = this.overwriteDiscoveryDocumentUrls ?
+            this.userinfoEndpoint || doc.userinfo_endpoint :
             doc.userinfo_endpoint || this.userinfoEndpoint;
-          this.jwksUri = doc.jwks_uri;
-          this.sessionCheckIFrameUrl =
+
+          this.jwksUri = this.overwriteDiscoveryDocumentUrls ?
+            this.jwksUri || doc.jwks_uri :
+            doc.jwks_uri || this.jwksUri;
+
+          this.sessionCheckIFrameUrl = this.overwriteDiscoveryDocumentUrls ?
+            this.sessionCheckIFrameUrl || doc.check_session_iframe :
             doc.check_session_iframe || this.sessionCheckIFrameUrl;
 
           this.discoveryDocumentLoaded = true;
           this.discoveryDocumentLoadedSubject.next(doc);
-          this.revocationEndpoint =
+          this.revocationEndpoint = this.overwriteDiscoveryDocumentUrls ?
+            this.revocationEndpoint || doc.revocation_endpoint :
             doc.revocation_endpoint || this.revocationEndpoint;
 
           if (this.sessionChecksEnabled) {


### PR DESCRIPTION
This will add a new option (overwriteDiscoveryDocumentUrls) to change behavior how the settable URLs from AuthConfig will be handled in relation to the discovery document.

maybe fixes #1161 too