### PR TITLE
use template literal when logging error

### DIFF
--- a/docs/injectables/OAuthService.html
+++ b/docs/injectables/OAuthService.html
@@ -9952,7 +9952,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             resolve(tokenResponse);
           },
           (err) &#x3D;&gt; {
-            this.logger.error(&#x27;Error performing ${grantType} flow&#x27;, err);
+            this.logger.error(&#x60;Error performing ${grantType} flow&#x60;, err);
             this.eventsSubject.next(new OAuthErrorEvent(&#x27;token_error&#x27;, err));
             reject(err);
           }

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -910,7 +910,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             resolve(tokenResponse);
           },
           (err) => {
-            this.logger.error('Error performing ${grantType} flow', err);
+            this.logger.error(`Error performing ${grantType} flow`, err);
             this.eventsSubject.next(new OAuthErrorEvent('token_error', err));
             reject(err);
           }


### PR DESCRIPTION

Use template literal so it can do proper string interpolation when logging a flow error.

