### PR TITLE
Undefined nonces should be equal in  IdToken processing

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2176,7 +2176,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     const claimsJson = b64DecodeUnicode(claimsBase64);
     const claims = JSON.parse(claimsJson);
 
-    let savedNonce;
+    let savedNonce = undefined;
     if (
       this.saveNoncesInLocalStorage &&
       typeof window['localStorage'] !== 'undefined'


### PR DESCRIPTION
Nonces are compared with strict equality `claims.nonce !== savedNonce`
If `savedNonce` is not defined then the default value is `null`.
If nonce attribute is missing on claims object, then the default value is `undefined`.

With strict equality this will cause an error. The `savedNonce` should be initialized with `undefined`

