### PR TITLE
issue-1294: Remove debug so it doesnt show.

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -395,7 +395,6 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
   protected setupRefreshTimer(): void {
     if (typeof window === 'undefined') {
-      this.debug('timer not supported on this plattform');
       return;
     }
 


### PR DESCRIPTION
Removes window `this.debug` so that it doesn't show in the angular universal terminal per issue here: 

https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1294