### PR TITLE
fixed issue 820 interceptor does not send expired access token

### DIFF
--- a/projects/lib/src/interceptors/default-oauth.interceptor.ts
+++ b/projects/lib/src/interceptors/default-oauth.interceptor.ts
@@ -64,7 +64,10 @@ export class DefaultOAuthInterceptor implements HttpInterceptor {
     }
 
     return merge(
-      of(this.oAuthService.getAccessToken()).pipe(filter((token) => !!token)),
+      of(this.oAuthService.hasValidAccessToken()).pipe(
+        filter((hasValidToken) => hasValidToken),
+        map(() => this.oAuthService.getAccessToken())
+      ),
       this.oAuthService.events.pipe(
         filter((e) => e.type === 'token_received'),
         timeout(this.oAuthService.waitForTokenInMsec || 0),


### PR DESCRIPTION
Fixed sending expired access tokens from interceptor by checking if it is valid before merging it into observable stream