### PR TITLE
chore: fixed broken link

### DIFF
--- a/docs/additional-documentation/popup-based-login.html
+++ b/docs/additional-documentation/popup-based-login.html
@@ -53,7 +53,7 @@
 <p>Thanks to a great community contribution, this library also supports logging the user in via a popup. For this, you need to do two things:</p>
 <ul>
 <li>Use <code>initLoginFlowInPopup</code> instead of <code>initLoginFlow</code>.</li>
-<li>Create and configure a <code>silent-refresh.html</code> as described <a href="./silent-refresh.md">here</a> *.</li>
+<li>Create and configure a <code>silent-refresh.html</code> as described <a href="./silent-refresh.html">here</a> *.</li>
 </ul>
 <p>* Please note this does not mean that you have to use silent refresh too.</p>
 <p>Also, for your <code>silent-refresh.html</code>, make sure you are also targeting


### PR DESCRIPTION
There was a broken URL inside of the `popup-based-login.html` pointing to the `.md` file instead of the `.html` one.