### PR TITLE
Fix missing template string in error log

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -912,7 +912,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             resolve(tokenResponse);
           },
           (err) => {
-            this.logger.error('Error performing ${grantType} flow', err);
+            this.logger.error(`Error performing ${grantType} flow`, err);
             this.eventsSubject.next(new OAuthErrorEvent('token_error', err));
             reject(err);
           }


### PR DESCRIPTION
The error log of the `fetchTokenUsingGrant` uses a template literal but within a normal string and therefore doesn't resolve the variable.

It seems like this was the only occurrence of this problem, based on a searching for `${`.