### PR TITLE
Correct the return type for getItem in MemoryStorage

### DIFF
--- a/projects/lib/src/types.ts
+++ b/projects/lib/src/types.ts
@@ -104,7 +104,7 @@ export abstract class OAuthStorage {
 export class MemoryStorage implements OAuthStorage {
   private data = new Map<string, string>();
 
-  getItem(key: string): string {
+  getItem(key: string): string | undefined {
     return this.data.get(key);
   }
 


### PR DESCRIPTION
The Memory storage uses a `Map` as backing storage. However, the `Map` return type for `get` is not purely `string`, it could also be `undefined`, hence this PR. (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get)

Another suggestion is that using `MemoryStorage` will save the nonce, if used, in memory as well, making it easy to make a whoopsie (see my other PR). Perhaps this `MemoryStorage` should at least warn about not saving a nonce there?