### PR TITLE
Fixes #1318 by multiplying decreaseExpirationBySec with 1000. Also fixes returning true for calling hasValidAccessToken on tokens which are already expired

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2266,7 +2266,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
     if (
       issuedAtMSec - clockSkewInMSec >= now ||
-      expiresAtMSec + clockSkewInMSec - this.decreaseExpirationBySec <= now
+      expiresAtMSec + clockSkewInMSec - this.decreaseExpirationBySec * 1000 <= now
     ) {
       const err = 'Token has expired';
       console.error(err);
@@ -2422,8 +2422,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
       const now = this.dateTimeService.new();
       if (
         expiresAt &&
-        parseInt(expiresAt, 10) - this.decreaseExpirationBySec <
-          now.getTime() - this.getClockSkewInMsec()
+        parseInt(expiresAt, 10) - this.decreaseExpirationBySec * 1000 < now.getTime()
       ) {
         return false;
       }
@@ -2443,7 +2442,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
       const now = this.dateTimeService.new();
       if (
         expiresAt &&
-        parseInt(expiresAt, 10) - this.decreaseExpirationBySec <
+        parseInt(expiresAt, 10) - this.decreaseExpirationBySec * 1000 <
           now.getTime() - this.getClockSkewInMsec()
       ) {
         return false;


### PR DESCRIPTION
In the "expires_at" is set and its calculated with local clock (see https://github.com/manfredsteyer/angular-oauth2-oidc/blob/15.0.0/projects/lib/src/oauth-service.ts#L1698 ). Therefore there is no need to appy clockSkewInMsec in hasValidAccessToken