### PR TITLE
Include origin check configuration to  session event handler

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1310,7 +1310,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
       this.debug('sessionCheckEventListener');
 
-      if (!issuer.startsWith(origin)) {
+      if (this.checkOrigin && !issuer.startsWith(origin)) {
         this.debug(
           'sessionCheckEventListener',
           'wrong origin',


### PR DESCRIPTION
Allow cross-domain iframe session check message handling, using existing configuration property from silentRefreshPostMessageEventListener