### PR TITLE
Added missing null in the type signature of getIdentityClaims in oauth-service.ts

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -2339,7 +2339,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
   /**
    * Returns the received claims about the user.
    */
-  public getIdentityClaims(): Record<string, any> {
+  public getIdentityClaims(): Record<string, any> | null {
     const claims = this._storage.getItem('id_token_claims_obj');
     if (!claims) {
       return null;


### PR DESCRIPTION
`null` is being returned but missing in type signature. This PR solves this issue.

```
public getIdentityClaims(): Record<string, any> {
  const claims = this._storage.getItem('id_token_claims_obj');
  if (!claims) {
    return null;
  }
  return JSON.parse(claims);
}
```