### PR TITLE
fix: actually block silent refreshing from other origins

### DIFF
--- a/projects/lib/src/auth.config.ts
+++ b/projects/lib/src/auth.config.ts
@@ -275,9 +275,14 @@ export class AuthConfig {
   public disableIdTokenTimer? = false;
 
   /**
-   * Blocks other origins requesting a silent refresh
+   * Checks whether other origins requesting a silent refresh and logs error
    */
   public checkOrigin? = false;
+
+  /**
+   * Blocks other origins requesting a silent refresh
+   */
+  public blockOtherOrigins? = false;
 
   constructor(json?: Partial<AuthConfig>) {
     if (json) {

--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1024,17 +1024,25 @@ export class OAuthService extends AuthConfig implements OnDestroy {
     this.silentRefreshPostMessageEventListener = (e: MessageEvent) => {
       const message = this.processMessageEventMessage(e);
 
-      if (this.checkOrigin && e.origin !== location.origin) {
-        console.error('wrong origin requested silent refresh!');
+      const hasDifferentOrigin = e.origin !== location.origin;
+
+      const shouldLogErrorForWrongOrigin = hasDifferentOrigin && (this.checkOrigin || this.blockOtherOrigins);
+
+      if (shouldLogErrorForWrongOrigin) {
+        console.error(`wrong origin requested silent refresh! expected: "${location.origin}", got: "${e.origin}"`);
       }
 
-      this.tryLogin({
-        customHashFragment: message,
-        preventClearHashAfterLogin: true,
-        customRedirectUri: this.silentRefreshRedirectUri || this.redirectUri,
-      }).catch((err) =>
-        this.debug('tryLogin during silent refresh failed', err)
-      );
+      const isAllowedToSilentRefresh = !hasDifferentOrigin || !this.blockOtherOrigins;
+
+      if (isAllowedToSilentRefresh) {
+        this.tryLogin({
+          customHashFragment: message,
+          preventClearHashAfterLogin: true,
+          customRedirectUri: this.silentRefreshRedirectUri || this.redirectUri,
+        }).catch((err) =>
+          this.debug('tryLogin during silent refresh failed', err)
+        );
+      }
     };
 
     window.addEventListener(

--- a/projects/quickstart-demo/src/app/auth.config.ts
+++ b/projects/quickstart-demo/src/app/auth.config.ts
@@ -9,4 +9,5 @@ export const authCodeFlowConfig: AuthConfig = {
   showDebugInformation: true,
   timeoutFactor: 0.01,
   checkOrigin: false,
+  blockOtherOrigins: false,
 };

--- a/projects/sample/src/app/auth.config.ts
+++ b/projects/sample/src/app/auth.config.ts
@@ -32,5 +32,7 @@ export const authConfig: AuthConfig = {
 
   checkOrigin: true,
 
+  blockOtherOrigins: true,
+
   timeoutFactor: 0.01,
 };


### PR DESCRIPTION
Fixes https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1354

- Maintains existing `checkOrigin` config for backwards compatibility; does not change functionality, only clarifies in doc comment that it only logs an error
- Adds new `blockOtherOrigins` config which prevents silent refreshing when the origin is different