### PR TITLE
throw token_error instead of token_refresh_error

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1956,7 +1956,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
           (err) => {
             console.error('Error getting token', err);
             this.eventsSubject.next(
-              new OAuthErrorEvent('token_refresh_error', err)
+              new OAuthErrorEvent('token_error', err)
             );
             reject(err);
           }


### PR DESCRIPTION
See #1451 

Getting a token with code flow throws the wrong error type, making distinction between getting a token and refreshing a token impossible