### PR TITLE
Skip nonce check when using password grant

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -901,7 +901,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
             if (this.oidc && tokenResponse.id_token) {
               this.processIdToken(
                 tokenResponse.id_token,
-                tokenResponse.access_token
+                tokenResponse.access_token,
+                grantType !== 'password'
               ).then((result) => {
                 this.storeIdToken(result);
                 resolve(tokenResponse);


### PR DESCRIPTION
Token responses from a password grant may return an id token, but these will never contain a nonce as there is no way to provide one. Therefore, in this scenario, the nonce validation should be skipped when processing the id token.

Fixes #1324