### PR TITLE
Clean iss param from location search after login

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1753,6 +1753,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
           .replace(/code=[^&$]*/, '')
           .replace(/scope=[^&$]*/, '')
           .replace(/state=[^&$]*/, '')
+          .replace(/iss=[^&$]*/, '')
           .replace(/session_state=[^&$]*/, '')
           .replace(/^\?&/, '?')
           .replace(/&$/, '')


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/draft-ietf-oauth-iss-auth-resp/00/ the issuer is appended to an authentication response with the iss query param.
Currently the angular-oauth2-oidc library ignores to clean that parameter after login. This results in a restoreState with appended iss query param.

This pr also cleans the iss parameter.

refers to -> https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1415