### PR TITLE
[Issue #1477] Use provided date for token validation

### DIFF
--- a/projects/angular-oauth2-oidc-jwks/src/lib/jwks-validation-handler.ts
+++ b/projects/angular-oauth2-oidc-jwks/src/lib/jwks-validation-handler.ts
@@ -13,10 +13,7 @@ import { Injector } from '@angular/core';
  * This jwks can be provided by the discovery document.
  */
 export class JwksValidationHandler extends AbstractValidationHandler {
-  constructor(
-    private injector?: Injector,
-    private validationOptions?: () => object
-  ) {
+  constructor(private injector?: Injector) {
     super();
   }
   /**
@@ -114,14 +111,10 @@ export class JwksValidationHandler extends AbstractValidationHandler {
     }
 
     const keyObj = this.getKey(key);
-    const customValidationOptions = {
-      ...(this.validationOptions ? this.validationOptions() : {}),
-    };
     const validationOptions = {
       alg: this.allowedAlgorithms,
       gracePeriod: this.gracePeriodInSec,
       verifyAt: this.verifyAt,
-      ...customValidationOptions,
     };
 
     const isValid = this.verifyJWT(params.idToken, keyObj, validationOptions);
@@ -153,17 +146,17 @@ export class JwksValidationHandler extends AbstractValidationHandler {
   }
 
   calcHash(valueToHash: string, algorithm: string): Promise<string> {
-    let hashAlg = new rs.KJUR.crypto.MessageDigest({ alg: algorithm });
-    let result = hashAlg.digestString(valueToHash);
-    let byteArrayAsString = this.toByteArrayAsString(result);
+    const hashAlg = new rs.KJUR.crypto.MessageDigest({ alg: algorithm });
+    const result = hashAlg.digestString(valueToHash);
+    const byteArrayAsString = this.toByteArrayAsString(result);
     return Promise.resolve(byteArrayAsString);
   }
 
   toByteArrayAsString(hexString: string) {
     let result = '';
     for (let i = 0; i < hexString.length; i += 2) {
-      let hexDigit = hexString.charAt(i) + hexString.charAt(i + 1);
-      let num = parseInt(hexDigit, 16);
+      const hexDigit = hexString.charAt(i) + hexString.charAt(i + 1);
+      const num = parseInt(hexDigit, 16);
       result += String.fromCharCode(num);
     }
     return result;

--- a/projects/angular-oauth2-oidc-jwks/src/lib/jwks-validation-handler.ts
+++ b/projects/angular-oauth2-oidc-jwks/src/lib/jwks-validation-handler.ts
@@ -172,7 +172,7 @@ export class JwksValidationHandler extends AbstractValidationHandler {
 
   private get verifyAt() {
     const now = this.dateTimeProvider?.new() || new Date();
-    const verifyAt = Math.floor(now.getTime() / 1000);
+    const verifyAt = now.getTime() / 1000;
     return verifyAt;
   }
 }

--- a/projects/angular-oauth2-oidc-jwks/src/lib/jwks-validation-handler.ts
+++ b/projects/angular-oauth2-oidc-jwks/src/lib/jwks-validation-handler.ts
@@ -134,11 +134,11 @@ export class JwksValidationHandler extends AbstractValidationHandler {
   }
 
   getKey(key: object) {
-    return rs.KEYUTIL.getKey(key);
+    return this.rs.KEYUTIL.getKey(key);
   }
 
   verifyJWT(idToken: string, keyObj: object, validationOptions: object) {
-    return rs.KJUR.jws.JWS.verifyJWT(idToken, keyObj, validationOptions);
+    return this.rs.KJUR.jws.JWS.verifyJWT(idToken, keyObj, validationOptions);
   }
 
   alg2kty(alg: string) {
@@ -167,6 +167,10 @@ export class JwksValidationHandler extends AbstractValidationHandler {
       result += String.fromCharCode(num);
     }
     return result;
+  }
+
+  get rs() {
+    return rs;
   }
 
   private get dateTimeProvider() {


### PR DESCRIPTION
In our company we have some agents that use a custom date and time on their computers, which has caused issues with the token validation. Currently, on the `JwksValidationHandler` on `angular-oauth2-oidc`, it uses the current client date to validate the token despite of the library providing a custom  `DateTimeProvider`.

In this pr I have made a modification to `JwksValidationHandler` to use the provided datetime on the token validation.

I have also separated the `jsrsasign` logic to clean up the code and expose those functions.

Hope you'll review it and feel free to add some comments

Fixes Issue https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1477