### PR TITLE
Clean iss parameter from Authorization response

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1743,7 +1743,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
 
     const code = parts['code'];
     const state = parts['state'];
-
+    
     const sessionState = parts['session_state'];
 
     if (!options.preventClearHashAfterLogin) {
@@ -1757,6 +1757,7 @@ export class OAuthService extends AuthConfig implements OnDestroy {
           .replace(/session_state=[^&$]*/, '')
           .replace(/^\?&/, '?')
           .replace(/&$/, '')
+          .replace(/iss=[^&\$]*/, '')
           .replace(/^\?$/, '')
           .replace(/&+/g, '&')
           .replace(/\?&/, '?')


### PR DESCRIPTION
[Relevant Issue](https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1213)
[Relevant Issue](https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1415)
As per [RFC 9207](https://datatracker.ietf.org/doc/rfc9207/) the issuer is appended to an authorization response as an "iss" query parameter.
Currently this library handles validating this claim but fails to clean it after login. This results in a URL still with the iss query parameter attached. 
This PR just utilises regex to clean the iss parameter.