### PR TITLE
Fixes #1500 When preventClearHashAfterLogin is false, the url replacement fails

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1753,8 +1753,8 @@ export class OAuthService extends AuthConfig implements OnDestroy {
         location.search
           .replace(/code=[^&$]*/, '')
           .replace(/scope=[^&$]*/, '')
-          .replace(/state=[^&$]*/, '')
           .replace(/session_state=[^&$]*/, '')
+          .replace(/state=[^&$]*/, '')
           .replace(/^\?&/, '?')
           .replace(/&$/, '')
           .replace(/^\?$/, '')


### PR DESCRIPTION
This PR fixes #1500 

See the ticket for all details of the problem.
As `state` and `session_state` have overlap in the name, the most specific must be removed first.